### PR TITLE
Make tests verbose on failure by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,9 @@ target_include_directories(nat20
 # when selected by setting `-DNAT20_WITH_TESTS=ON` on the `cmake --build` command line.
 if (NAT20_WITH_TESTS)
 
+    # Print test details if tests fail.
+    set(CMAKE_CTEST_ARGUMENTS "--output-on-failure")
+
     include(FetchContent)
 
     FetchContent_Declare(


### PR DESCRIPTION
Making the test verbose when failures occur leads to more actionable output in case of a test failure.