### PR TITLE
Fix `n20_crypto_boringssl_key_get_public_key` not setting `public_key_size_in_out` for large buffers

### DIFF
--- a/src/crypto/crypto_boringssl.cpp
+++ b/src/crypto/crypto_boringssl.cpp
@@ -520,6 +520,8 @@ static n20_crypto_error_t n20_crypto_boringssl_key_get_public_key(struct n20_cry
             }
             auto x962_key_info_guard = std::unique_ptr<uint8_t, BoringsslDeleter>(x962_key_info);
 
+            *public_key_size_in_out = public_key_size;
+
             // The key size should be exactly twice the key size + one byte for
             // the compression header, which must be 0x04 indication no compression.
             if ((size_t)rc_der_len != *public_key_size_in_out + 1 || x962_key_info[0] != 0x04) {
@@ -537,11 +539,6 @@ static n20_crypto_error_t n20_crypto_boringssl_key_get_public_key(struct n20_cry
                 // If this happened this implementation handed out
                 // inconsistent data or the user did something undefined.
                 return n20_crypto_error_implementation_specific_e;
-            }
-
-            if (*public_key_size_in_out < 32 || public_key_out == nullptr) {
-                *public_key_size_in_out = 32;
-                return n20_crypto_error_insufficient_buffer_size_e;
             }
 
             auto rc =

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -765,6 +765,17 @@ TYPED_TEST_P(CryptoTestFixture, GetPublicKeyErrorsTest) {
         // must contain the correct maximal required buffer size.
         N20_ASSERT_EQ(want_key_size, public_key_size);
 
+        // Must return n20_crypto_error_ok_e if the the buffer size is sufficient.
+        uint8_t large_public_key_buffer[256];
+        public_key_size = sizeof(large_public_key_buffer);
+        N20_ASSERT_EQ(n20_crypto_error_ok_e,
+                      this->ctx->key_get_public_key(
+                          this->ctx, key, large_public_key_buffer, &public_key_size));
+
+        // If n20_crypto_error_ok_e was returned public_key_size must contain the correct maximal
+        // required buffer size.
+        N20_ASSERT_EQ(want_key_size, public_key_size);
+
         N20_ASSERT_EQ(n20_crypto_error_ok_e, this->ctx->key_free(this->ctx, key));
     }
 


### PR DESCRIPTION
`n20_crypto_boringssl_key_get_public_key` wasn't properly setting `public_key_size_in_out` for EC keys. A unit test asserting the right `public_key_size_out` was added and was failing as expected. The fix was then applied and the unit test passes as expected.

A redundant check for ED25519 keys was also removed.