### PR TITLE
Consolidate error codes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(LIBNAT20_PUB_HEADERS
     # These files will be included in the generation of the API documentation.
     include/nat20/asn1.h
     include/nat20/crypto.h
+    include/nat20/error.h
     include/nat20/oid.h
     include/nat20/stream.h
     include/nat20/types.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,8 @@ endif() # NAT20_WITH_TESTS
 
 ###################################################################################################
 # The doxygen docs generation target is only created if enabled by setting `-DNAT20_WITH_DOCS=ON`
-# on the `cmake --build` command line.
+# on the `cmake -B` command line.
+
 if (NAT20_WITH_DOCS)
 
     find_package(Doxygen REQUIRED dot)

--- a/include/nat20/crypto.h
+++ b/include/nat20/crypto.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <nat20/error.h>
 #include <nat20/types.h>
 #include <stdint.h>
 #include <unistd.h>
@@ -25,194 +26,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief Error codes that may be returned by a crypto interface implementation.
- */
-enum n20_crypto_error_s {
-    /**
-     * @brief No error occurred.
-     */
-    n20_crypto_error_ok_e = 0,
-    /**
-     * @brief The crypto context given to an interface was invalid.
-     *
-     * Implementations must return this error if the context given is
-     * NULL.
-     * Implementation may deploy additional techniques to determine
-     * if the context given is valid.
-     */
-    n20_crypto_error_invalid_context_e = 1,
-    /**
-     * @brief Indicates that an input key argument was NULL.
-     *
-     * Interface function implementations that expect a `key_in`
-     * parameter return this error said parameter receives a NULL
-     * argument.
-     *
-     * @sa n20_crypto_context_t.kdf
-     * @sa n20_crypto_context_t.sign
-     */
-    n20_crypto_error_unexpected_null_key_in_e = 2,
-    /**
-     * @brief Indicates that an output key argument was NULL.
-     *
-     * Interface function implementations that expect a `key_out`
-     * parameter return this error said parameter receives a NULL
-     * argument.
-     *
-     * @sa n20_crypto_context_t.kdf
-     * @sa n20_crypto_context_t.get_cdi
-     */
-    n20_crypto_error_unexpected_null_key_out_e = 3,
-    /**
-     * @brief Indicates that a size output argument was NULL.
-     *
-     * Interface function implementations that expect a `*_size_in_out`
-     * parameter return this error said parameter receives a NULL
-     * argument.
-     *
-     * @sa n20_crypto_context_t.digest
-     * @sa n20_crypto_context_t.sign
-     * @sa n20_crypto_context_t.key_public_key
-     */
-    n20_crypto_error_unexpected_null_size_e = 4,
-    /**
-     * @brief Indicates that the user data input argument was NULL.
-     *
-     * Functions that receive unformatted user data, like
-     * the message for `sign` and `digest` or the
-     * the key derivation context of `kdf` return this
-     * error if the data parameter receives a NULL argument.
-     *
-     * @sa n20_crypto_context_t.digest
-     * @sa n20_crypto_context_t.sign
-     * @sa n20_crypto_context_t.kdf
-     */
-    n20_crypto_error_unexpected_null_data_e = 5,
-    /**
-     * @brief Indicates that the user data input argument was NULL.
-     *
-     * Functions that receive unformatted user data, like
-     * the message for `sign` and `digest` or the
-     * the key derivation context of `kdf` return this
-     * error if the if @ref n20_crypto_gather_list_t.count is
-     * non zero but @ref n20_crypto_gather_list_t.list is NULL.
-     *
-     * @sa n20_crypto_context_t.digest
-     * @sa n20_crypto_context_t.sign
-     * @sa n20_crypto_context_t.kdf
-     */
-    n20_crypto_error_unexpected_null_list_e = 6,
-    /**
-     * @brief Indicates that the user data input argument was NULL.
-     *
-     * Functions that receive unformatted user data, like
-     * the message for `sign` and `digest` or the
-     * the key derivation context of `kdf` return this
-     * error the gather list contains a slice
-     * with @ref n20_slice_t.size non zero but
-     * @ref n20_slice_t.buffer is NULL.
-     *
-     * @sa n20_crypto_context_t.digest
-     * @sa n20_crypto_context_t.kdf
-     * @sa n20_crypto_context_t.sign
-     */
-    n20_crypto_error_unexpected_null_slice_e = 7,
-    /**
-     * @brief This should not be used outside of development.
-     *
-     * During development of a new crypto interface implementation
-     * this error can be returned by yet unimplemented functions.
-     * It may never be returned in complete implementations.
-     *
-     * It may be used in the future to toggle tests depending on
-     * unimplemented functions in debug builds. Release builds
-     * must never tolerate unimplemented errors however.
-     */
-    n20_crypto_error_not_implemented_e = 8,
-    /**
-     * @brief Indicates that an unkown algorithm was selected.
-     *
-     * Interface functions that expect an algorithm selector
-     * return this error if the selected algorithm is
-     * outside of the selected range.
-     *
-     * @sa n20_crypto_context_t.digest
-     */
-    n20_crypto_error_unkown_algorithm_e = 9,
-    /**
-     * @brief Indicates that the key input argument is unsuitable for the requested operation.
-     *
-     * Interface functions that expect a `key_in` argument
-     * must check if the given key is suitable for the requested
-     * operation and return this error if it is not.
-     *
-     * @sa n20_crypto_context_t.kdf
-     * @sa n20_crypto_context_t.sign
-     * @sa n20_crypto_context_t.key_public_key
-     */
-    n20_crypto_error_invalid_key_e = 10,
-    /**
-     * @brief Indicates that the requested key type is out of range.
-     *
-     * Interface functions that expect a `key_type_in` argument
-     * return this error if the selected key type is outside of
-     * defined range.
-     *
-     * @sa n20_crypto_context_t.kdf
-     */
-    n20_crypto_error_invalid_key_type_e = 11,
-    /**
-     * @brief Indicates that the user supplied buffer is insufficient.
-     *
-     * Interface functions that require the user to allocate an output buffer
-     * return this error if the supplied buffer size is too small or
-     * if the output buffer argument was NULL.
-     *
-     * Important: If this error is returned, the corresponding `*_size_in_out`
-     * parameter must be set to the maximal required buffer size required by
-     * the implementation to successfully complete the function call.
-     * This must always be possible because if the `*_size_in_out` argument was
-     * NULL, the function must have returned
-     * @ref n20_crypto_error_unexpected_null_size_e.
-     *
-     * @sa n20_crypto_context_t.digest
-     * @sa n20_crypto_context_t.sign
-     * @sa n20_crypto_context_t.key_public_key
-     */
-    n20_crypto_error_insufficient_buffer_size_e = 12,
-    /**
-     * @brief Indicates that an unexpected null pointer was received as argument.
-     *
-     * This generic variant of the error should not be used by
-     * implementations of any of the interface functions, rather it is returned
-     * by implementation specific factory functions indicating that
-     * one of their implementation specific arguments was unexpectedly
-     * NULL.
-     */
-    n20_crypto_error_unexpected_null_e = 13,
-    /**
-     * @brief Indicates that the implementation ran out of a critical resource.
-     *
-     * Interface functions may return this error if they failed to
-     * perform an operation due to a lack of physical resources.
-     * This includes memory allocation errors.
-     */
-    n20_crypto_error_no_resources_e = 14,
-    /**
-     * @brief Indicates that an implementation specific error has occurred.
-     *
-     * This is a catch all for unexpected errors that can be encountered
-     * by an implementation.
-     */
-    n20_crypto_error_implementation_specific_e = 15,
-};
-
-/**
- * @brief Alias for @ref n20_crypto_error_s
- */
-typedef enum n20_crypto_error_s n20_crypto_error_t;
 
 /**
  * @brief Enumeration of supported digest algorithms.
@@ -361,37 +174,37 @@ struct n20_crypto_context_s {
      *
      * ## Errors
      *
-     * - @ref n20_crypto_error_invalid_context_e must be returned
+     * - @ref n20_error_crypto_invalid_context_e must be returned
      *   if ctx is NULL.
      *   Additional mechanisms may be implemented to determine
      *   if the context is valid, but an implementation must
      *   accept an instance if it was created with the implementation
      *   specific factory and not freed.
-     * - @ref n20_crypto_error_unexpected_null_size_e must be returned
+     * - @ref n20_error_crypto_unexpected_null_size_e must be returned
      *   if @p digest_size_in_out is NULL.
-     * - @ref n20_crypto_error_unkown_algorithm_e must be returned if
+     * - @ref n20_error_crypto_unkown_algorithm_e must be returned if
      *   @p alg_in is out of range.
-     * - @ref n20_crypto_error_insufficient_buffer_size_e must be returned
+     * - @ref n20_error_crypto_insufficient_buffer_size_e must be returned
      *   if @p digest_out is NULL or if @p digest_size_in_out indicates
      *   that the given buffer has insufficient capacity for the resulting
      *   digest. In this case the implementation MUST set
      *   @p digest_size_in_out to the size required by the algorithm
      *   selected in @p alg_in.
-     * - @ref n20_crypto_error_unexpected_null_data_e must be returned
+     * - @ref n20_error_crypto_unexpected_null_data_e must be returned
      *   if none of the above conditions were met AND @p msg_in is NULL.
      *   This means that `msg_in == NULL` MUST be tolerated when
      *   querying the output buffer size.
-     * - @ref n20_crypto_error_unexpected_null_list_e must be returned
+     * - @ref n20_error_crypto_unexpected_null_list_e must be returned
      *   if @ref n20_crypto_gather_list_t.count in @p msg_in is not `0`
      *   and @ref n20_crypto_gather_list_t.list in @p msg_in is NULL.
-     * - @ref n20_crypto_error_unexpected_null_slice_e must be returned if
+     * - @ref n20_error_crypto_unexpected_null_slice_e must be returned if
      *   the @p msg_in gather list contains a buffer that has non zero
      *   size but a buffer that is NULL.
      *
-     * Implementations may return @ref n20_crypto_error_no_resources_e if
+     * Implementations may return @ref n20_error_crypto_no_resources_e if
      * any kind of internal resource allocation failed.
      *
-     * Implementations may return @ref n20_crypto_error_implementation_specific_e.
+     * Implementations may return @ref n20_error_crypto_implementation_specific_e.
      * However, it is impossible to meaningfully recover from this error, therefore,
      * it is strongly discouraged for implementations to return this error,
      * and given the nature of the algorithms, it should never be necessary to do so.
@@ -404,11 +217,11 @@ struct n20_crypto_context_s {
      * @param digest_size_in_out On input the capacity of the given buffer.
      *        On output the size of the digest.
      */
-    n20_crypto_error_t (*digest)(struct n20_crypto_context_s* ctx,
-                                 n20_crypto_digest_algorithm_t alg_in,
-                                 n20_crypto_gather_list_t const* msg_in,
-                                 uint8_t* digest_out,
-                                 size_t* digest_size_in_out);
+    n20_error_t (*digest)(struct n20_crypto_context_s* ctx,
+                          n20_crypto_digest_algorithm_t alg_in,
+                          n20_crypto_gather_list_t const* msg_in,
+                          uint8_t* digest_out,
+                          size_t* digest_size_in_out);
 
     /**
      * @brief Derive a key from an opaque secret and context.
@@ -438,14 +251,14 @@ struct n20_crypto_context_s {
      *
      * ## Example
      * @code{.c}
-     * n20_crypto_error_t rc;
+     * n20_error_t rc;
      *
      * n20_crypto_context_s *ctx = open_my_crypto_implementation();
      *
      * // Get local cdi.
      * n20_crypto_key_t cdi = NULL;
      * rc = ctx->get_cdi(ctx, &cdi);
-     * if (rc != n20_crypto_error_ok_e) {
+     * if (rc != n20_error_ok_e) {
      *     // error handling
      * }
      *
@@ -463,7 +276,7 @@ struct n20_crypto_context_s {
      * // Perform key derivation.
      * n20_crypto_key_t derived_key = nullptr;
      * rc = ctx->kdf(ctx, cdi, n20_crypto_key_type_ed25519_e, &context, &derived_key);
-     * if (rc != n20_crypto_error_ok_e) {
+     * if (rc != n20_error_ok_e) {
      *     // error handling
      * }
      *
@@ -471,39 +284,39 @@ struct n20_crypto_context_s {
      *
      * // Clean up.
      * rc = ctx->key_free(ctx, derived_key);
-     * if (rc != n20_crypto_error_ok_e) {
+     * if (rc != n20_error_ok_e) {
      *     // error handling
      * }
      *
      * rc = ctx->key_free(ctx, cdi);
-     * if (rc != n20_crypto_error_ok_e) {
+     * if (rc != n20_error_ok_e) {
      *     // error handling
      * }
      *
      * @endcode
      *
      * ## Errors
-     * - @ref n20_crypto_error_invalid_context_e must be returned
+     * - @ref n20_error_crypto_invalid_context_e must be returned
      *   if ctx is NULL.
      *   Additional mechanisms may be implemented to determine
      *   if the context is valid, but an implementation must
      *   accept an instance if it was created with the implementation
      *   specific factory and not freed.
-     * - @ref n20_crypto_error_unexpected_null_key_in_e must be returned
+     * - @ref n20_error_crypto_unexpected_null_key_in_e must be returned
      *   if the @p key_in is NULL.
-     * - @ref n20_crypto_error_invalid_key_e must be returned if
+     * - @ref n20_error_crypto_invalid_key_e must be returned if
      *   @p key_in is not of the type @ref n20_crypto_key_type_cdi_e.
-     * - @ref n20_crypto_error_unexpected_null_key_out_e must be returned
+     * - @ref n20_error_crypto_unexpected_null_key_out_e must be returned
      *   if @p key_out is NULL.
-     * - @ref n20_crypto_error_unexpected_null_data_e must be returned
+     * - @ref n20_error_crypto_unexpected_null_data_e must be returned
      *   if @p context_in is NULL.
-     * - @ref n20_crypto_error_unexpected_null_list_e must be returned
+     * - @ref n20_error_crypto_unexpected_null_list_e must be returned
      *   if @ref n20_crypto_gather_list_t.count in @p context_in is not `0`
      *   and @ref n20_crypto_gather_list_t.list in @p context_in is NULL.
-     * - @ref n20_crypto_error_unexpected_null_slice_e must be returned if
+     * - @ref n20_error_crypto_unexpected_null_slice_e must be returned if
      *   the @p context_in gather list contains a buffer that has non zero
      *   size but a buffer that is NULL.
-     * - @ref n20_crypto_error_invalid_key_type_e must be returned
+     * - @ref n20_error_crypto_invalid_key_type_e must be returned
      *   if @p key_type_in is not in the range given by @ref n20_crypto_key_type_t.
      *
      * @param ctx The crypto context.
@@ -512,11 +325,11 @@ struct n20_crypto_context_s {
      * @param context_in A gatherlist describing the context of the to-be-derived key.
      * @param key_out Output buffer for the derived key handle.
      */
-    n20_crypto_error_t (*kdf)(struct n20_crypto_context_s* ctx,
-                              n20_crypto_key_t key_in,
-                              n20_crypto_key_type_t key_type_in,
-                              n20_crypto_gather_list_t const* context_in,
-                              n20_crypto_key_t* key_out);
+    n20_error_t (*kdf)(struct n20_crypto_context_s* ctx,
+                       n20_crypto_key_t key_in,
+                       n20_crypto_key_type_t key_type_in,
+                       n20_crypto_gather_list_t const* context_in,
+                       n20_crypto_key_t* key_out);
     /**
      * @brief Sign a message using an opaque key handle.
      *
@@ -533,34 +346,34 @@ struct n20_crypto_context_s {
      *   leading zeroes if necessary.
      *
      * ## Errors
-     * - @ref n20_crypto_error_invalid_context_e must be returned
+     * - @ref n20_error_crypto_invalid_context_e must be returned
      *   if ctx is NULL.
      *   Additional mechanisms may be implemented to determine
      *   if the context is valid, but an implementation must
      *   accept an instance if it was created with the implementation
      *   specific factory and not freed.
-     * - @ref n20_crypto_error_unexpected_null_key_in_e must be returned
+     * - @ref n20_error_crypto_unexpected_null_key_in_e must be returned
      *   if the @p key_in is NULL.
-     * - @ref n20_crypto_error_unexpected_null_size_e must be returned if
+     * - @ref n20_error_crypto_unexpected_null_size_e must be returned if
      *   @p signature_size_in_out is NULL.
-     * - @ref n20_crypto_error_invalid_key_e must be returned
+     * - @ref n20_error_crypto_invalid_key_e must be returned
      *   if @p key_in is not of the types @ref n20_crypto_key_type_ed25519_e,
      *   @ref n20_crypto_key_type_secp256r1_e, or
      *   @ref n20_crypto_key_type_secp384r1_e.
-     * - @ref n20_crypto_error_unexpected_null_data_e must be returned
+     * - @ref n20_error_crypto_unexpected_null_data_e must be returned
      *   if @p context_in is NULL.
-     * - @ref n20_crypto_error_insufficient_buffer_size_e if
+     * - @ref n20_error_crypto_insufficient_buffer_size_e if
      *   @p signature_out is NULL or if @p *signature_size_in_out indicates
      *   that the given buffer is too small.
-     *   If @ref n20_crypto_error_insufficient_buffer_size_e is returned
+     *   If @ref n20_error_crypto_insufficient_buffer_size_e is returned
      *   the implementation must set @p *signature_size_in_out to the maximum
      *   required buffer size for the signature algorithm requested.
-     * - @ref n20_crypto_error_unexpected_null_data_e must be returned
+     * - @ref n20_error_crypto_unexpected_null_data_e must be returned
      *   if @p msg_in is NULL.
-     * - @ref n20_crypto_error_unexpected_null_list_e must be returned
+     * - @ref n20_error_crypto_unexpected_null_list_e must be returned
      *   if @ref n20_crypto_gather_list_t.count in @p msg_in is not `0`
      *   and @ref n20_crypto_gather_list_t.list in @p msg_in is NULL.
-     * - @ref n20_crypto_error_unexpected_null_slice_e must be returned if
+     * - @ref n20_error_crypto_unexpected_null_slice_e must be returned if
      *   the @p msg_in gather list contains a buffer that has non zero
      *   size but a buffer that is NULL.
      *
@@ -572,11 +385,11 @@ struct n20_crypto_context_s {
      *        given buffer (in) and the size of the required/used signature
      *        buffer (out).
      */
-    n20_crypto_error_t (*sign)(struct n20_crypto_context_s* ctx,
-                               n20_crypto_key_t key_in,
-                               n20_crypto_gather_list_t const* msg_in,
-                               uint8_t* signature_out,
-                               size_t* signature_size_in_out);
+    n20_error_t (*sign)(struct n20_crypto_context_s* ctx,
+                        n20_crypto_key_t key_in,
+                        n20_crypto_gather_list_t const* msg_in,
+                        uint8_t* signature_out,
+                        size_t* signature_size_in_out);
     /**
      * @brief Return the local cdi handle.
      *
@@ -588,20 +401,20 @@ struct n20_crypto_context_s {
      * The CDI key handle must be destroyed with @ref key_free.
      *
      * ## Errors
-     * - @ref n20_crypto_error_invalid_context_e must be returned
+     * - @ref n20_error_crypto_invalid_context_e must be returned
      *   if ctx is NULL.
      *   Additional mechanisms may be implemented to determine
      *   if the context is valid, but an implementation must
      *   accept an instance if it was created with the implementation
      *   specific factory and not freed.
-     * - @ref n20_crypto_error_unexpected_null_key_out_e must be returned
+     * - @ref n20_error_crypto_unexpected_null_key_out_e must be returned
      *   if @p key_out is NULL.
      *
      * @param ctx The crypto context.
      * @param key_out A buffer to take the opaque key handle of the root
      *        secret that is the local CDI.
      */
-    n20_crypto_error_t (*get_cdi)(struct n20_crypto_context_s* ctx, n20_crypto_key_t* key_out);
+    n20_error_t (*get_cdi)(struct n20_crypto_context_s* ctx, n20_crypto_key_t* key_out);
     /**
      * @brief Export the public key of an asymmetric key.
      *
@@ -619,29 +432,29 @@ struct n20_crypto_context_s {
      * The caller must provide a sufficiently sized buffer as @p public_key_out
      * setting @p *public_key_size_in_out to the correct buffer size.
      * The required buffer size can be queried by setting @p public_key_out
-     * to NULL. In that case @ref n20_crypto_error_insufficient_buffer_size_e
+     * to NULL. In that case @ref n20_error_crypto_insufficient_buffer_size_e
      * is returned and @p *public_key_size_in_out is set to the required buffer
      * size.
      *
      * ## Errors
-     * - @ref n20_crypto_error_invalid_context_e must be returned
+     * - @ref n20_error_crypto_invalid_context_e must be returned
      *   if ctx is NULL.
      *   Additional mechanisms may be implemented to determine
      *   if the context is valid, but an implementation must
      *   accept an instance if it was created with the implementation
      *   specific factory and not freed.
-     * - @ref n20_crypto_error_unexpected_null_key_in_e must be returned
+     * - @ref n20_error_crypto_unexpected_null_key_in_e must be returned
      *   if the @p key_in is NULL.
-     * - @ref n20_crypto_error_unexpected_null_size_e must be returned if
+     * - @ref n20_error_crypto_unexpected_null_size_e must be returned if
      *   @p public_key_size_in_out is NULL.
-     * - @ref n20_crypto_error_invalid_key_e must be returned
+     * - @ref n20_error_crypto_invalid_key_e must be returned
      *   if @p key_in is not of the types @ref n20_crypto_key_type_ed25519_e,
      *   @ref n20_crypto_key_type_secp256r1_e, or
      *   @ref n20_crypto_key_type_secp384r1_e.
-     * - @ref n20_crypto_error_insufficient_buffer_size_e if
+     * - @ref n20_error_crypto_insufficient_buffer_size_e if
      *   @p public_key_out is NULL or if @p *public_key_size_in_out indicates
      *   that the given buffer is too small.
-     *   If @ref n20_crypto_error_insufficient_buffer_size_e is returned
+     *   If @ref n20_error_crypto_insufficient_buffer_size_e is returned
      *   the implementation must set @p *public_key_size_in_out to the maximum
      *   required buffer size for the signature algorithm requested.
      *
@@ -653,10 +466,10 @@ struct n20_crypto_context_s {
      *        given buffer (in) and the size of the required/used public key
      *        buffer (out).
      */
-    n20_crypto_error_t (*key_get_public_key)(struct n20_crypto_context_s* ctx,
-                                             n20_crypto_key_t key_in,
-                                             uint8_t* public_key_out,
-                                             size_t* public_key_size_in_out);
+    n20_error_t (*key_get_public_key)(struct n20_crypto_context_s* ctx,
+                                      n20_crypto_key_t key_in,
+                                      uint8_t* public_key_out,
+                                      size_t* public_key_size_in_out);
     /**
      * @brief Destroy a key handle.
      *
@@ -665,10 +478,10 @@ struct n20_crypto_context_s {
      * Unless an invalid context is given, this function shall not fail.
      *
      * Passing NULL as @p key_in is explicitly allowed and yield
-     * @ref n20_crypto_error_ok_e.
+     * @ref n20_error_ok_e.
      *
      * ## Errors
-     * - @ref n20_crypto_error_invalid_context_e must be returned
+     * - @ref n20_error_crypto_invalid_context_e must be returned
      *   if ctx is NULL.
      *   Additional mechanisms may be implemented to determine
      *   if the context is valid, but an implementation must
@@ -678,7 +491,7 @@ struct n20_crypto_context_s {
      * @param ctx The crypto context.
      * @param key_in The key handle to be freed.
      */
-    n20_crypto_error_t (*key_free)(struct n20_crypto_context_s* ctx, n20_crypto_key_t key_in);
+    n20_error_t (*key_free)(struct n20_crypto_context_s* ctx, n20_crypto_key_t key_in);
 };
 
 /**

--- a/include/nat20/crypto.h
+++ b/include/nat20/crypto.h
@@ -182,7 +182,7 @@ struct n20_crypto_context_s {
      *   specific factory and not freed.
      * - @ref n20_error_crypto_unexpected_null_size_e must be returned
      *   if @p digest_size_in_out is NULL.
-     * - @ref n20_error_crypto_unkown_algorithm_e must be returned if
+     * - @ref n20_error_crypto_unknown_algorithm_e must be returned if
      *   @p alg_in is out of range.
      * - @ref n20_error_crypto_insufficient_buffer_size_e must be returned
      *   if @p digest_out is NULL or if @p digest_size_in_out indicates

--- a/include/nat20/crypto_bssl/crypto.h
+++ b/include/nat20/crypto_bssl/crypto.h
@@ -17,14 +17,15 @@
 #pragma once
 
 #include <nat20/crypto.h>
+#include <nat20/error.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-n20_crypto_error_t n20_crypto_open_boringssl(n20_crypto_context_t** ctx, n20_slice_t const* cdi);
+n20_error_t n20_crypto_open_boringssl(n20_crypto_context_t** ctx, n20_slice_t const* cdi);
 
-n20_crypto_error_t n20_crypto_close_boringssl(n20_crypto_context_t* ctx);
+n20_error_t n20_crypto_close_boringssl(n20_crypto_context_t* ctx);
 
 #ifdef __cplusplus
 }

--- a/include/nat20/error.h
+++ b/include/nat20/error.h
@@ -102,7 +102,7 @@ enum n20_error_s {
      * Functions that receive unformatted user data, like
      * the message for `sign` and `digest` or the
      * the key derivation context of `kdf` return this
-     * error if the if @ref n20_crypto_gather_list_t.count is
+     * error if @ref n20_crypto_gather_list_t.count is
      * non zero but @ref n20_crypto_gather_list_t.list is NULL.
      *
      * @sa n20_crypto_context_t.digest

--- a/include/nat20/error.h
+++ b/include/nat20/error.h
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2025 Aurora Operations, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Error codes that may be returned by a libnat20 service function.
+ *
+ * This includes errors related to crypto operations, service context issues,
+ * and other service-related errors.
+ *
+ * The error codes permitted by the crypto backend implementation are n20_error_ok_e
+ * and n20_error_crypto_*_e.
+ */
+enum n20_error_s {
+    /**
+     * @brief No error occurred.
+     */
+    n20_error_ok_e = 0,
+    /**
+     * @brief The crypto context given to an interface was invalid.
+     *
+     * Implementations must return this error if the context given is
+     * NULL.
+     * Implementation may deploy additional techniques to determine
+     * if the context given is valid.
+     */
+    n20_error_crypto_invalid_context_e = 0x10001,
+    /**
+     * @brief Indicates that an input key argument was NULL.
+     *
+     * Interface function implementations that expect a `key_in`
+     * parameter return this error said parameter receives a NULL
+     * argument.
+     *
+     * @sa n20_crypto_context_t.kdf
+     * @sa n20_crypto_context_t.sign
+     */
+    n20_error_crypto_unexpected_null_key_in_e = 0x10002,
+    /**
+     * @brief Indicates that an output key argument was NULL.
+     *
+     * Interface function implementations that expect a `key_out`
+     * parameter return this error said parameter receives a NULL
+     * argument.
+     *
+     * @sa n20_crypto_context_t.kdf
+     * @sa n20_crypto_context_t.get_cdi
+     */
+    n20_error_crypto_unexpected_null_key_out_e = 0x10003,
+    /**
+     * @brief Indicates that a size output argument was NULL.
+     *
+     * Interface function implementations that expect a `*_size_in_out`
+     * parameter return this error said parameter receives a NULL
+     * argument.
+     *
+     * @sa n20_crypto_context_t.digest
+     * @sa n20_crypto_context_t.sign
+     * @sa n20_crypto_context_t.key_public_key
+     */
+    n20_error_crypto_unexpected_null_size_e = 0x10004,
+    /**
+     * @brief Indicates that the user data input argument was NULL.
+     *
+     * Functions that receive unformatted user data, like
+     * the message for `sign` and `digest` or the
+     * the key derivation context of `kdf` return this
+     * error if the data parameter receives a NULL argument.
+     *
+     * @sa n20_crypto_context_t.digest
+     * @sa n20_crypto_context_t.sign
+     * @sa n20_crypto_context_t.kdf
+     */
+    n20_error_crypto_unexpected_null_data_e = 0x10005,
+    /**
+     * @brief Indicates that the user data input argument was NULL.
+     *
+     * Functions that receive unformatted user data, like
+     * the message for `sign` and `digest` or the
+     * the key derivation context of `kdf` return this
+     * error if the if @ref n20_crypto_gather_list_t.count is
+     * non zero but @ref n20_crypto_gather_list_t.list is NULL.
+     *
+     * @sa n20_crypto_context_t.digest
+     * @sa n20_crypto_context_t.sign
+     * @sa n20_crypto_context_t.kdf
+     */
+    n20_error_crypto_unexpected_null_list_e = 0x10006,
+    /**
+     * @brief Indicates that the user data input argument was NULL.
+     *
+     * Functions that receive unformatted user data, like
+     * the message for `sign` and `digest` or the
+     * the key derivation context of `kdf` return this
+     * error the gather list contains a slice
+     * with @ref n20_slice_t.size non zero but
+     * @ref n20_slice_t.buffer is NULL.
+     *
+     * @sa n20_crypto_context_t.digest
+     * @sa n20_crypto_context_t.kdf
+     * @sa n20_crypto_context_t.sign
+     */
+    n20_error_crypto_unexpected_null_slice_e = 0x10007,
+    /**
+     * @brief This should not be used outside of development.
+     *
+     * During development of a new crypto interface implementation
+     * this error can be returned by yet unimplemented functions.
+     * It may never be returned in complete implementations.
+     *
+     * It may be used in the future to toggle tests depending on
+     * unimplemented functions in debug builds. Release builds
+     * must never tolerate unimplemented errors however.
+     */
+    n20_error_crypto_not_implemented_e = 0x10008,
+    /**
+     * @brief Indicates that an unkown algorithm was selected.
+     *
+     * Interface functions that expect an algorithm selector
+     * return this error if the selected algorithm is
+     * outside of the selected range.
+     *
+     * @sa n20_crypto_context_t.digest
+     */
+    n20_error_crypto_unkown_algorithm_e = 0x10009,
+    /**
+     * @brief Indicates that the key input argument is unsuitable for the requested operation.
+     *
+     * Interface functions that expect a `key_in` argument
+     * must check if the given key is suitable for the requested
+     * operation and return this error if it is not.
+     *
+     * @sa n20_crypto_context_t.kdf
+     * @sa n20_crypto_context_t.sign
+     * @sa n20_crypto_context_t.key_public_key
+     */
+    n20_error_crypto_invalid_key_e = 0x1000a,
+    /**
+     * @brief Indicates that the requested key type is out of range.
+     *
+     * Interface functions that expect a `key_type_in` argument
+     * return this error if the selected key type is outside of
+     * defined range.
+     *
+     * @sa n20_crypto_context_t.kdf
+     */
+    n20_error_crypto_invalid_key_type_e = 0x1000b,
+    /**
+     * @brief Indicates that the user supplied buffer is insufficient.
+     *
+     * Interface functions that require the user to allocate an output buffer
+     * return this error if the supplied buffer size is too small or
+     * if the output buffer argument was NULL.
+     *
+     * Important: If this error is returned, the corresponding `*_size_in_out`
+     * parameter must be set to the maximal required buffer size required by
+     * the implementation to successfully complete the function call.
+     * This must always be possible because if the `*_size_in_out` argument was
+     * NULL, the function must have returned
+     * @ref n20_error_crypto_unexpected_null_size_e.
+     *
+     * @sa n20_crypto_context_t.digest
+     * @sa n20_crypto_context_t.sign
+     * @sa n20_crypto_context_t.key_public_key
+     */
+    n20_error_crypto_insufficient_buffer_size_e = 0x1000c,
+    /**
+     * @brief Indicates that an unexpected null pointer was received as argument.
+     *
+     * This generic variant of the error should not be used by
+     * implementations of any of the interface functions, rather it is returned
+     * by implementation specific factory functions indicating that
+     * one of their implementation specific arguments was unexpectedly
+     * NULL.
+     */
+    n20_error_crypto_unexpected_null_e = 0x1000d,
+    /**
+     * @brief Indicates that the implementation ran out of a critical resource.
+     *
+     * Interface functions may return this error if they failed to
+     * perform an operation due to a lack of physical resources.
+     * This includes memory allocation errors.
+     */
+    n20_error_crypto_no_resources_e = 0x1000e,
+    /**
+     * @brief Indicates that an implementation specific error has occurred.
+     *
+     * This is a catch all for unexpected errors that can be encountered
+     * by an implementation.
+     */
+    n20_error_crypto_implementation_specific_e = 0x1000f,
+};
+
+/**
+ * @brief Alias for @ref n20_error_s
+ */
+typedef enum n20_error_s n20_error_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/nat20/error.h
+++ b/include/nat20/error.h
@@ -27,7 +27,7 @@ extern "C" {
  * and other service-related errors.
  *
  * The error codes permitted by the crypto backend implementation are n20_error_ok_e
- * and n20_error_crypto_*_e.
+ * and n20_error_crypto_*_e. Crypto errors are in the range 0x1000 to 0x1FFF.
  */
 enum n20_error_s {
     /**

--- a/include/nat20/error.h
+++ b/include/nat20/error.h
@@ -42,7 +42,7 @@ enum n20_error_s {
      * Implementation may deploy additional techniques to determine
      * if the context given is valid.
      */
-    n20_error_crypto_invalid_context_e = 0x10001,
+    n20_error_crypto_invalid_context_e = 0x1001,
     /**
      * @brief Indicates that an input key argument was NULL.
      *
@@ -53,7 +53,7 @@ enum n20_error_s {
      * @sa n20_crypto_context_t.kdf
      * @sa n20_crypto_context_t.sign
      */
-    n20_error_crypto_unexpected_null_key_in_e = 0x10002,
+    n20_error_crypto_unexpected_null_key_in_e = 0x1002,
     /**
      * @brief Indicates that an output key argument was NULL.
      *
@@ -64,7 +64,7 @@ enum n20_error_s {
      * @sa n20_crypto_context_t.kdf
      * @sa n20_crypto_context_t.get_cdi
      */
-    n20_error_crypto_unexpected_null_key_out_e = 0x10003,
+    n20_error_crypto_unexpected_null_key_out_e = 0x1003,
     /**
      * @brief Indicates that a size output argument was NULL.
      *
@@ -76,7 +76,7 @@ enum n20_error_s {
      * @sa n20_crypto_context_t.sign
      * @sa n20_crypto_context_t.key_public_key
      */
-    n20_error_crypto_unexpected_null_size_e = 0x10004,
+    n20_error_crypto_unexpected_null_size_e = 0x1004,
     /**
      * @brief Indicates that the user data input argument was NULL.
      *
@@ -89,7 +89,7 @@ enum n20_error_s {
      * @sa n20_crypto_context_t.sign
      * @sa n20_crypto_context_t.kdf
      */
-    n20_error_crypto_unexpected_null_data_e = 0x10005,
+    n20_error_crypto_unexpected_null_data_e = 0x1005,
     /**
      * @brief Indicates that the user data input argument was NULL.
      *
@@ -103,7 +103,7 @@ enum n20_error_s {
      * @sa n20_crypto_context_t.sign
      * @sa n20_crypto_context_t.kdf
      */
-    n20_error_crypto_unexpected_null_list_e = 0x10006,
+    n20_error_crypto_unexpected_null_list_e = 0x1006,
     /**
      * @brief Indicates that the user data input argument was NULL.
      *
@@ -118,7 +118,7 @@ enum n20_error_s {
      * @sa n20_crypto_context_t.kdf
      * @sa n20_crypto_context_t.sign
      */
-    n20_error_crypto_unexpected_null_slice_e = 0x10007,
+    n20_error_crypto_unexpected_null_slice_e = 0x1007,
     /**
      * @brief This should not be used outside of development.
      *
@@ -130,7 +130,7 @@ enum n20_error_s {
      * unimplemented functions in debug builds. Release builds
      * must never tolerate unimplemented errors however.
      */
-    n20_error_crypto_not_implemented_e = 0x10008,
+    n20_error_crypto_not_implemented_e = 0x1008,
     /**
      * @brief Indicates that an unknown algorithm was selected.
      *
@@ -140,7 +140,7 @@ enum n20_error_s {
      *
      * @sa n20_crypto_context_t.digest
      */
-    n20_error_crypto_unknown_algorithm_e = 0x10009,
+    n20_error_crypto_unknown_algorithm_e = 0x1009,
     /**
      * @brief Indicates that the key input argument is unsuitable for the requested operation.
      *
@@ -152,7 +152,7 @@ enum n20_error_s {
      * @sa n20_crypto_context_t.sign
      * @sa n20_crypto_context_t.key_public_key
      */
-    n20_error_crypto_invalid_key_e = 0x1000a,
+    n20_error_crypto_invalid_key_e = 0x100a,
     /**
      * @brief Indicates that the requested key type is out of range.
      *
@@ -162,7 +162,7 @@ enum n20_error_s {
      *
      * @sa n20_crypto_context_t.kdf
      */
-    n20_error_crypto_invalid_key_type_e = 0x1000b,
+    n20_error_crypto_invalid_key_type_e = 0x100b,
     /**
      * @brief Indicates that the user supplied buffer is insufficient.
      *
@@ -181,7 +181,7 @@ enum n20_error_s {
      * @sa n20_crypto_context_t.sign
      * @sa n20_crypto_context_t.key_public_key
      */
-    n20_error_crypto_insufficient_buffer_size_e = 0x1000c,
+    n20_error_crypto_insufficient_buffer_size_e = 0x100c,
     /**
      * @brief Indicates that an unexpected null pointer was received as argument.
      *
@@ -191,7 +191,7 @@ enum n20_error_s {
      * one of their implementation specific arguments was unexpectedly
      * NULL.
      */
-    n20_error_crypto_unexpected_null_e = 0x1000d,
+    n20_error_crypto_unexpected_null_e = 0x100d,
     /**
      * @brief Indicates that the implementation ran out of a critical resource.
      *
@@ -199,14 +199,14 @@ enum n20_error_s {
      * perform an operation due to a lack of physical resources.
      * This includes memory allocation errors.
      */
-    n20_error_crypto_no_resources_e = 0x1000e,
+    n20_error_crypto_no_resources_e = 0x100e,
     /**
      * @brief Indicates that an implementation specific error has occurred.
      *
      * This is a catch all for unexpected errors that can be encountered
      * by an implementation.
      */
-    n20_error_crypto_implementation_specific_e = 0x1000f,
+    n20_error_crypto_implementation_specific_e = 0x100f,
 };
 
 /**

--- a/include/nat20/error.h
+++ b/include/nat20/error.h
@@ -132,7 +132,7 @@ enum n20_error_s {
      */
     n20_error_crypto_not_implemented_e = 0x10008,
     /**
-     * @brief Indicates that an unkown algorithm was selected.
+     * @brief Indicates that an unknown algorithm was selected.
      *
      * Interface functions that expect an algorithm selector
      * return this error if the selected algorithm is
@@ -140,7 +140,7 @@ enum n20_error_s {
      *
      * @sa n20_crypto_context_t.digest
      */
-    n20_error_crypto_unkown_algorithm_e = 0x10009,
+    n20_error_crypto_unknown_algorithm_e = 0x10009,
     /**
      * @brief Indicates that the key input argument is unsuitable for the requested operation.
      *

--- a/include/nat20/error.h
+++ b/include/nat20/error.h
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+/**
+ * @file error.h
+ *
+ * @brief Error code definitions for libnat20.
+ */
+
 #pragma once
 
 #ifdef __cplusplus

--- a/src/core/test/x509.cpp
+++ b/src/core/test/x509.cpp
@@ -605,24 +605,24 @@ TEST_P(CertTest, CertEncoding) {
     // Create a key with test_cdi.
     n20_crypto_context_t* ctx = nullptr;
     n20_slice_t cdi_slice{.size = sizeof(test_cdi), .buffer = test_cdi};
-    n20_crypto_error_t err = n20_crypto_open_boringssl(&ctx, &cdi_slice);
-    ASSERT_EQ(n20_crypto_error_ok_e, err);
+    n20_error_t err = n20_crypto_open_boringssl(&ctx, &cdi_slice);
+    ASSERT_EQ(n20_error_ok_e, err);
 
     n20_crypto_key_t cdi_key = nullptr;
     err = ctx->get_cdi(ctx, &cdi_key);
-    ASSERT_EQ(n20_crypto_error_ok_e, err);
+    ASSERT_EQ(n20_error_ok_e, err);
 
     n20_crypto_gather_list_t empty_context{.count = 0, .list = nullptr};
 
     n20_crypto_key_t signing_key = nullptr;
     err = ctx->kdf(ctx, cdi_key, key_type, &empty_context, &signing_key);
-    ASSERT_EQ(n20_crypto_error_ok_e, err);
+    ASSERT_EQ(n20_error_ok_e, err);
 
     uint8_t public_key_buffer[128];
     uint8_t* public_key = &public_key_buffer[1];
     size_t public_key_size = sizeof(public_key_buffer) - 1;
     err = ctx->key_get_public_key(ctx, signing_key, public_key, &public_key_size);
-    ASSERT_EQ(n20_crypto_error_ok_e, err);
+    ASSERT_EQ(n20_error_ok_e, err);
 
     if (key_type != n20_crypto_key_type_ed25519_e) {
         public_key_buffer[0] = 0x04;
@@ -702,7 +702,7 @@ TEST_P(CertTest, CertEncoding) {
     uint8_t signature[128];
     size_t signature_size = sizeof(signature);
     err = ctx->sign(ctx, signing_key, &tbs_der_gather, signature, &signature_size);
-    ASSERT_EQ(n20_crypto_error_ok_e, err);
+    ASSERT_EQ(n20_error_ok_e, err);
     ctx->key_free(ctx, signing_key);
     n20_crypto_close_boringssl(ctx);
 
@@ -774,21 +774,21 @@ TEST_P(CertTest, CertEncoding) {
     n20_crypto_context_t* ctx2 = nullptr;
     n20_slice_t cdi_slice2{.size = sizeof(test_cdi2), .buffer = test_cdi2};
     err = n20_crypto_open_boringssl(&ctx2, &cdi_slice2);
-    ASSERT_EQ(n20_crypto_error_ok_e, err);
+    ASSERT_EQ(n20_error_ok_e, err);
 
     n20_crypto_key_t cdi_key2 = nullptr;
     err = ctx2->get_cdi(ctx2, &cdi_key2);
-    ASSERT_EQ(n20_crypto_error_ok_e, err);
+    ASSERT_EQ(n20_error_ok_e, err);
 
     n20_crypto_key_t signing_key2 = nullptr;
     err = ctx2->kdf(ctx2, cdi_key2, key_type, &empty_context, &signing_key2);
-    ASSERT_EQ(n20_crypto_error_ok_e, err);
+    ASSERT_EQ(n20_error_ok_e, err);
 
     uint8_t public_key_buffer2[128];
     uint8_t* public_key2 = &public_key_buffer2[1];
     size_t public_key_size2 = sizeof(public_key_buffer2) - 1;
     err = ctx2->key_get_public_key(ctx2, signing_key2, public_key2, &public_key_size2);
-    ASSERT_EQ(n20_crypto_error_ok_e, err);
+    ASSERT_EQ(n20_error_ok_e, err);
 
     if (key_type != n20_crypto_key_type_ed25519_e) {
         public_key_buffer2[0] = 0x04;
@@ -810,7 +810,7 @@ TEST_P(CertTest, CertEncoding) {
     uint8_t signature2[128];
     size_t signature_size2 = sizeof(signature2);
     err = ctx2->sign(ctx2, signing_key2, &tbs_der_gather2, signature2, &signature_size2);
-    ASSERT_EQ(n20_crypto_error_ok_e, err);
+    ASSERT_EQ(n20_error_ok_e, err);
     ctx2->key_free(ctx2, signing_key2);
     n20_crypto_close_boringssl(ctx2);
 

--- a/src/crypto/crypto_boringssl.cpp
+++ b/src/crypto/crypto_boringssl.cpp
@@ -16,6 +16,7 @@
 
 #include <nat20/crypto.h>
 #include <nat20/crypto_bssl/crypto.h>
+#include <nat20/error.h>
 #include <openssl/base.h>
 #include <openssl/bn.h>
 #include <openssl/digest.h>
@@ -107,54 +108,54 @@ static size_t digest_enum_to_size(n20_crypto_digest_algorithm_t alg_in) {
     }
 }
 
-static n20_crypto_error_t n20_crypto_boringssl_digest(struct n20_crypto_context_s* ctx,
-                                                      n20_crypto_digest_algorithm_t alg_in,
-                                                      n20_crypto_gather_list_t const* msg_in,
-                                                      uint8_t* digest_out,
-                                                      size_t* digest_size_in_out) {
+static n20_error_t n20_crypto_boringssl_digest(struct n20_crypto_context_s* ctx,
+                                               n20_crypto_digest_algorithm_t alg_in,
+                                               n20_crypto_gather_list_t const* msg_in,
+                                               uint8_t* digest_out,
+                                               size_t* digest_size_in_out) {
     if (ctx == nullptr) {
-        return n20_crypto_error_invalid_context_e;
+        return n20_error_crypto_invalid_context_e;
     }
 
     if (digest_size_in_out == NULL) {
-        return n20_crypto_error_unexpected_null_size_e;
+        return n20_error_crypto_unexpected_null_size_e;
     }
 
     EVP_MD const* md = digest_enum_to_bssl_evp_md(alg_in);
     if (md == nullptr) {
-        return n20_crypto_error_unkown_algorithm_e;
+        return n20_error_crypto_unkown_algorithm_e;
     }
     size_t digest_size = digest_enum_to_size(alg_in);
 
     // If the provided buffer size is too small or no buffer was provided
     // set the required buffer size and return
-    // n20_crypto_error_insufficient_buffer_size_e.
+    // n20_error_crypto_insufficient_buffer_size_e.
     if (digest_size > *digest_size_in_out || digest_out == nullptr) {
         *digest_size_in_out = digest_size;
-        return n20_crypto_error_insufficient_buffer_size_e;
+        return n20_error_crypto_insufficient_buffer_size_e;
     }
 
     // It can be tolerated above if no message was given.
     // The caller might just query the required buffer size.
     // But from here a message must be provided.
     if (msg_in == nullptr) {
-        return n20_crypto_error_unexpected_null_data_e;
+        return n20_error_crypto_unexpected_null_data_e;
     }
 
     if (msg_in->count != 0 && msg_in->list == nullptr) {
-        return n20_crypto_error_unexpected_null_list_e;
+        return n20_error_crypto_unexpected_null_list_e;
     }
 
     auto md_ctx = EVP_MD_CTX_PTR_t(EVP_MD_CTX_new());
 
     if (!EVP_DigestInit(md_ctx.get(), md)) {
-        return n20_crypto_error_no_resources_e;
+        return n20_error_crypto_no_resources_e;
     }
 
     for (size_t i = 0; i < msg_in->count; ++i) {
         if (msg_in->list[i].size == 0) continue;
         if (msg_in->list[i].buffer == nullptr) {
-            return n20_crypto_error_unexpected_null_slice_e;
+            return n20_error_crypto_unexpected_null_slice_e;
         }
         EVP_DigestUpdate(md_ctx.get(), msg_in->list[i].buffer, msg_in->list[i].size);
     }
@@ -165,24 +166,24 @@ static n20_crypto_error_t n20_crypto_boringssl_digest(struct n20_crypto_context_
 
     *digest_size_in_out = out_size;
 
-    return n20_crypto_error_ok_e;
+    return n20_error_ok_e;
 }
 
-static std::variant<n20_crypto_error_t, std::vector<uint8_t> const> gather_list_to_vector(
+static std::variant<n20_error_t, std::vector<uint8_t> const> gather_list_to_vector(
     n20_crypto_gather_list_t const* list) {
     std::vector<uint8_t> result;
     if (list == nullptr) {
-        return n20_crypto_error_unexpected_null_data_e;
+        return n20_error_crypto_unexpected_null_data_e;
     }
 
     if (list->count != 0 && list->list == nullptr) {
-        return n20_crypto_error_unexpected_null_list_e;
+        return n20_error_crypto_unexpected_null_list_e;
     }
 
     for (size_t i = 0; i < list->count; ++i) {
         if (list->list[i].size == 0) continue;
         if (list->list[i].buffer == NULL) {
-            return n20_crypto_error_unexpected_null_slice_e;
+            return n20_error_crypto_unexpected_null_slice_e;
         }
         result.insert(
             result.end(), list->list[i].buffer, list->list[i].buffer + list->list[i].size);
@@ -202,7 +203,7 @@ static std::variant<n20_crypto_error_t, std::vector<uint8_t> const> gather_list_
  * and generates a k value that is used for signing.
  *
  * The function returns a variant that can either be an error code
- * (of type n20_crypto_error_t) or a pointer to a BIGNUM
+ * (of type n20_error_t) or a pointer to a BIGNUM
  * (of type BIGNUM_PTR_t) that represents the generated k value.
  *
  * In this context this method is used to deterministically generate
@@ -212,7 +213,7 @@ static std::variant<n20_crypto_error_t, std::vector<uint8_t> const> gather_list_
  * (x) is a seed that is deterministically derived from a CDI and
  * the context of the key to be derived.
  */
-static std::variant<n20_crypto_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
+static std::variant<n20_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
     std::vector<uint8_t> const& x_octets,
     std::optional<std::vector<uint8_t>> const& m_octets,
     n20_crypto_digest_algorithm_t digest_algorithm,
@@ -220,7 +221,7 @@ static std::variant<n20_crypto_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
 
     auto md = digest_enum_to_bssl_evp_md(digest_algorithm);
     if (md == nullptr) {
-        return n20_crypto_error_unkown_algorithm_e;
+        return n20_error_crypto_unkown_algorithm_e;
     }
 
     auto digest_size = digest_enum_to_size(digest_algorithm);
@@ -235,7 +236,7 @@ static std::variant<n20_crypto_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
         if (!EVP_Digest(
                 m_octets->data(), m_octets->size(), h1_digest.data(), &out_size, md, NULL) ||
             out_size != digest_size) {
-            return n20_crypto_error_implementation_specific_e;
+            return n20_error_crypto_implementation_specific_e;
         }
         /*
          * The message digest needs to be converted to an octet sequence using
@@ -248,7 +249,7 @@ static std::variant<n20_crypto_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
          */
         auto h1_bn = BIGNUM_PTR_t(BN_bin2bn(h1_digest.data(), h1_digest.size(), NULL));
         if (h1_bn.get() == nullptr) {
-            return n20_crypto_error_no_resources_e;
+            return n20_error_crypto_no_resources_e;
         }
 
         /*
@@ -258,7 +259,7 @@ static std::variant<n20_crypto_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
          */
         if (h1_digest.size() * 8 > qlen) {
             if (!BN_rshift(h1_bn.get(), h1_bn.get(), h1_digest.size() * 8 - qlen)) {
-                return n20_crypto_error_no_resources_e;
+                return n20_error_crypto_no_resources_e;
             }
         }
 
@@ -268,22 +269,22 @@ static std::variant<n20_crypto_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
          */
         auto h1_bn2 = BIGNUM_PTR_t(BN_new());
         if (h1_bn2.get() == nullptr) {
-            return n20_crypto_error_no_resources_e;
+            return n20_error_crypto_no_resources_e;
         }
 
         if (!BN_sub(h1_bn2.get(), h1_bn.get(), q)) {
-            return n20_crypto_error_no_resources_e;
+            return n20_error_crypto_no_resources_e;
         }
 
         h1.resize(rlen);
 
         if (BN_is_negative(h1_bn2.get())) {
             if (!BN_bn2bin_padded(h1.data(), rlen, h1_bn.get())) {
-                return n20_crypto_error_no_resources_e;
+                return n20_error_crypto_no_resources_e;
             }
         } else {
             if (!BN_bn2bin_padded(h1.data(), rlen, h1_bn2.get())) {
-                return n20_crypto_error_no_resources_e;
+                return n20_error_crypto_no_resources_e;
             }
         }
 
@@ -297,7 +298,7 @@ static std::variant<n20_crypto_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
 
     auto hmac_ctx = HMAC_CTX_PTR_t(HMAC_CTX_new());
     if (hmac_ctx == nullptr) {
-        return n20_crypto_error_no_resources_e;
+        return n20_error_crypto_no_resources_e;
     }
 
     uint8_t internal_octet = 0;
@@ -309,7 +310,7 @@ static std::variant<n20_crypto_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
     do {
         /* Update K. */
         if (!HMAC_Init_ex(hmac_ctx.get(), K.data(), K.size(), md, NULL)) {
-            return n20_crypto_error_no_resources_e;
+            return n20_error_crypto_no_resources_e;
         }
 
         HMAC_Update(hmac_ctx.get(), V.data(), V.size());
@@ -319,13 +320,13 @@ static std::variant<n20_crypto_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
             HMAC_Update(hmac_ctx.get(), h1.data(), h1.size());
         }
         if (!HMAC_Final(hmac_ctx.get(), K.data(), &out_size) || out_size != digest_size) {
-            return n20_crypto_error_implementation_specific_e;
+            return n20_error_crypto_implementation_specific_e;
         }
 
         /* Update V. */
         if (!HMAC(md, K.data(), K.size(), V.data(), V.size(), V.data(), &out_size) ||
             out_size != digest_size) {
-            return n20_crypto_error_implementation_specific_e;
+            return n20_error_crypto_implementation_specific_e;
         }
         internal_octet += 1;
 
@@ -352,7 +353,7 @@ static std::variant<n20_crypto_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
             /* Update V. */
             if (!HMAC(md, K.data(), K.size(), V.data(), V.size(), V.data(), &out_size) ||
                 out_size != digest_size) {
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
 
             std::copy(V.begin(), V.end(), T.begin() + i * digest_size);
@@ -366,11 +367,11 @@ static std::variant<n20_crypto_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
          */
         k = BIGNUM_PTR_t(BN_bin2bn(T.data(), T.size(), NULL));
         if (k.get() == nullptr) {
-            return n20_crypto_error_no_resources_e;
+            return n20_error_crypto_no_resources_e;
         }
 
         if (!BN_rshift(k.get(), k.get(), T.size() * 8 - qlen)) {
-            return n20_crypto_error_no_resources_e;
+            return n20_error_crypto_no_resources_e;
         }
 
         if (!BN_is_zero(k.get()) && BN_cmp(k.get(), q) < 0) {
@@ -380,23 +381,23 @@ static std::variant<n20_crypto_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
 
         /* Update K. */
         if (!HMAC_Init_ex(hmac_ctx.get(), K.data(), K.size(), md, NULL)) {
-            return n20_crypto_error_no_resources_e;
+            return n20_error_crypto_no_resources_e;
         }
         HMAC_Update(hmac_ctx.get(), V.data(), V.size());
         HMAC_Update(hmac_ctx.get(), &internal_octet, 1);
         if (!HMAC_Final(hmac_ctx.get(), K.data(), &out_size) || out_size != digest_size) {
-            return n20_crypto_error_implementation_specific_e;
+            return n20_error_crypto_implementation_specific_e;
         }
 
         /* Update V. */
         if (!HMAC(md, K.data(), K.size(), V.data(), V.size(), V.data(), &out_size) ||
             out_size != digest_size) {
-            return n20_crypto_error_implementation_specific_e;
+            return n20_error_crypto_implementation_specific_e;
         }
     }
 }
 
-std::variant<n20_crypto_error_t, bssl::UniquePtr<BIGNUM>> __n20_testing_rfc6979_k_generation(
+std::variant<n20_error_t, bssl::UniquePtr<BIGNUM>> __n20_testing_rfc6979_k_generation(
     std::vector<uint8_t> const& x_octets,
     std::optional<std::vector<uint8_t>> const& m_octets,
     n20_crypto_digest_algorithm_t digest_algorithm,
@@ -404,32 +405,32 @@ std::variant<n20_crypto_error_t, bssl::UniquePtr<BIGNUM>> __n20_testing_rfc6979_
     return rfc6979_k_generation(x_octets, m_octets, digest_algorithm, q);
 }
 
-static n20_crypto_error_t n20_crypto_boringssl_kdf(struct n20_crypto_context_s* ctx,
-                                                   n20_crypto_key_t key_in,
-                                                   n20_crypto_key_type_t key_type_in,
-                                                   n20_crypto_gather_list_t const* context_in,
-                                                   n20_crypto_key_t* key_out) {
+static n20_error_t n20_crypto_boringssl_kdf(struct n20_crypto_context_s* ctx,
+                                            n20_crypto_key_t key_in,
+                                            n20_crypto_key_type_t key_type_in,
+                                            n20_crypto_gather_list_t const* context_in,
+                                            n20_crypto_key_t* key_out) {
     if (ctx == nullptr) {
-        return n20_crypto_error_invalid_context_e;
+        return n20_error_crypto_invalid_context_e;
     }
 
     if (key_in == NULL) {
-        return n20_crypto_error_unexpected_null_key_in_e;
+        return n20_error_crypto_unexpected_null_key_in_e;
     }
 
     auto bssl_base_key = reinterpret_cast<n20_bssl_key_base*>(key_in);
     if (bssl_base_key->type != n20_crypto_key_type_cdi_e) {
-        return n20_crypto_error_invalid_key_e;
+        return n20_error_crypto_invalid_key_e;
     }
 
     auto bssl_cdi_key = static_cast<n20_bssl_cdi_key*>(bssl_base_key);
 
     if (key_out == NULL) {
-        return n20_crypto_error_unexpected_null_key_out_e;
+        return n20_error_crypto_unexpected_null_key_out_e;
     }
 
     auto const context_error = gather_list_to_vector(context_in);
-    if (auto error = std::get_if<n20_crypto_error_t>(&context_error)) {
+    if (auto error = std::get_if<n20_error_t>(&context_error)) {
         return *error;
     }
 
@@ -445,7 +446,7 @@ static n20_crypto_error_t n20_crypto_boringssl_kdf(struct n20_crypto_context_s* 
                          context.data(),
                          context.size());
     if (!rc) {
-        return n20_crypto_error_implementation_specific_e;
+        return n20_error_crypto_implementation_specific_e;
     }
 
     switch (key_type_in) {
@@ -453,23 +454,23 @@ static n20_crypto_error_t n20_crypto_boringssl_kdf(struct n20_crypto_context_s* 
             auto key = EVP_PKEY_PTR_t(EVP_PKEY_new_raw_private_key(
                 EVP_PKEY_ED25519, NULL, derived.data(), derived.size()));
             if (!key) {
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
             auto bssl_out = new n20_bssl_evp_pkey();
             if (bssl_out == NULL) {
-                return n20_crypto_error_no_resources_e;
+                return n20_error_crypto_no_resources_e;
             }
             bssl_out->type = key_type_in;
             bssl_out->key = std::move(key);
             *key_out = bssl_out;
-            return n20_crypto_error_ok_e;
+            return n20_error_ok_e;
         }
         case n20_crypto_key_type_cdi_e: {
             auto bssl_out = new n20_bssl_cdi_key();
             bssl_out->type = key_type_in;
             bssl_out->bits = std::move(derived);
             *key_out = bssl_out;
-            return n20_crypto_error_ok_e;
+            return n20_error_ok_e;
         }
         case n20_crypto_key_type_secp256r1_e:
         case n20_crypto_key_type_secp384r1_e: {
@@ -482,18 +483,18 @@ static n20_crypto_error_t n20_crypto_boringssl_kdf(struct n20_crypto_context_s* 
 
             auto q = EC_GROUP_get0_order(ec_group);
             if (q == nullptr) {
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
 
             auto private_key = rfc6979_k_generation(
                 derived, /*m_octets=*/std::nullopt, n20_crypto_digest_algorithm_sha2_512_e, q);
-            if (auto error = std::get_if<n20_crypto_error_t>(&private_key)) {
+            if (auto error = std::get_if<n20_error_t>(&private_key)) {
                 return *error;
             }
 
             auto public_key = EC_POINT_PTR_t(EC_POINT_new(ec_group));
             if (public_key.get() == nullptr) {
-                return n20_crypto_error_no_resources_e;
+                return n20_error_crypto_no_resources_e;
             }
 
             if (!EC_POINT_mul(ec_group,
@@ -502,29 +503,29 @@ static n20_crypto_error_t n20_crypto_boringssl_kdf(struct n20_crypto_context_s* 
                               NULL,
                               NULL,
                               NULL)) {
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
 
             auto ec_key = EC_KEY_PTR_t(EC_KEY_new());
             if (ec_key == nullptr) {
-                return n20_crypto_error_no_resources_e;
+                return n20_error_crypto_no_resources_e;
             }
 
             if (!EC_KEY_set_group(ec_key.get(), ec_group)) {
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
 
             if (!EC_KEY_set_private_key(ec_key.get(), std::get<BIGNUM_PTR_t>(private_key).get())) {
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
 
             if (!EC_KEY_set_public_key(ec_key.get(), public_key.get())) {
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
 
             auto key = EVP_PKEY_PTR_t(EVP_PKEY_new());
             if (!key) {
-                return n20_crypto_error_no_resources_e;
+                return n20_error_crypto_no_resources_e;
             }
 
             EVP_PKEY_assign_EC_KEY(key.get(), ec_key.release());
@@ -533,41 +534,41 @@ static n20_crypto_error_t n20_crypto_boringssl_kdf(struct n20_crypto_context_s* 
             bssl_out->type = key_type_in;
             bssl_out->key = std::move(key);
             *key_out = bssl_out;
-            return n20_crypto_error_ok_e;
+            return n20_error_ok_e;
         }
     }
 
-    return n20_crypto_error_invalid_key_type_e;
+    return n20_error_crypto_invalid_key_type_e;
 }
 
-static n20_crypto_error_t n20_crypto_boringssl_sign(struct n20_crypto_context_s* ctx,
-                                                    n20_crypto_key_t key_in,
-                                                    n20_crypto_gather_list_t const* msg_in,
-                                                    uint8_t* signature_out,
-                                                    size_t* signature_size_in_out) {
+static n20_error_t n20_crypto_boringssl_sign(struct n20_crypto_context_s* ctx,
+                                             n20_crypto_key_t key_in,
+                                             n20_crypto_gather_list_t const* msg_in,
+                                             uint8_t* signature_out,
+                                             size_t* signature_size_in_out) {
 
     if (ctx == nullptr) {
-        return n20_crypto_error_invalid_context_e;
+        return n20_error_crypto_invalid_context_e;
     }
 
     if (key_in == nullptr) {
-        return n20_crypto_error_unexpected_null_key_in_e;
+        return n20_error_crypto_unexpected_null_key_in_e;
     }
 
     if (signature_size_in_out == nullptr) {
-        return n20_crypto_error_unexpected_null_size_e;
+        return n20_error_crypto_unexpected_null_size_e;
     }
 
     auto bssl_base_key = reinterpret_cast<n20_bssl_key_base*>(key_in);
     if (bssl_base_key->type == n20_crypto_key_type_cdi_e) {
-        return n20_crypto_error_invalid_key_e;
+        return n20_error_crypto_invalid_key_e;
     }
 
     auto bssl_evp_key = static_cast<n20_bssl_evp_pkey*>(bssl_base_key);
 
     auto md_ctx = EVP_MD_CTX_PTR_t(EVP_MD_CTX_new());
     if (!md_ctx) {
-        return n20_crypto_error_no_resources_e;
+        return n20_error_crypto_no_resources_e;
     }
 
     constexpr size_t ed25519_signature_size = 64;
@@ -589,22 +590,22 @@ static n20_crypto_error_t n20_crypto_boringssl_sign(struct n20_crypto_context_s*
             break;
         case n20_crypto_key_type_cdi_e:
         default:
-            return n20_crypto_error_invalid_key_e;
+            return n20_error_crypto_invalid_key_e;
     }
 
     if (*signature_size_in_out < signature_size || signature_out == nullptr) {
         *signature_size_in_out = signature_size;
-        return n20_crypto_error_insufficient_buffer_size_e;
+        return n20_error_crypto_insufficient_buffer_size_e;
     }
 
     switch (bssl_base_key->type) {
         case n20_crypto_key_type_ed25519_e: {
             if (1 != EVP_DigestSignInit(md_ctx.get(), NULL, md, NULL, bssl_evp_key->key.get())) {
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
 
             auto const msg_error = gather_list_to_vector(msg_in);
-            if (auto error = std::get_if<n20_crypto_error_t>(&msg_error)) {
+            if (auto error = std::get_if<n20_error_t>(&msg_error)) {
                 return *error;
             }
 
@@ -613,22 +614,22 @@ static n20_crypto_error_t n20_crypto_boringssl_sign(struct n20_crypto_context_s*
             if (1 !=
                 EVP_DigestSign(
                     md_ctx.get(), signature_out, signature_size_in_out, msg.data(), msg.size())) {
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
 
-            return n20_crypto_error_ok_e;
+            return n20_error_ok_e;
         }
         case n20_crypto_key_type_secp256r1_e:
         case n20_crypto_key_type_secp384r1_e: {
             if (msg_in == NULL) {
-                return n20_crypto_error_unexpected_null_data_e;
+                return n20_error_crypto_unexpected_null_data_e;
             }
             if (msg_in->count != 0 && msg_in->list == nullptr) {
-                return n20_crypto_error_unexpected_null_list_e;
+                return n20_error_crypto_unexpected_null_list_e;
             }
 
             if (1 != EVP_DigestSignInit(md_ctx.get(), NULL, md, NULL, bssl_evp_key->key.get())) {
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
 
             for (size_t i = 0; i < msg_in->count; ++i) {
@@ -636,12 +637,12 @@ static n20_crypto_error_t n20_crypto_boringssl_sign(struct n20_crypto_context_s*
                 if (msg_in->list[i].size == 0) continue;
                 // But non empty segments cannot have nullptr buffers.
                 if (msg_in->list[i].buffer == nullptr) {
-                    return n20_crypto_error_unexpected_null_slice_e;
+                    return n20_error_crypto_unexpected_null_slice_e;
                 }
 
                 if (1 != EVP_DigestSignUpdate(
                              md_ctx.get(), msg_in->list[i].buffer, msg_in->list[i].size)) {
-                    return n20_crypto_error_implementation_specific_e;
+                    return n20_error_crypto_implementation_specific_e;
                 }
             }
 
@@ -650,7 +651,7 @@ static n20_crypto_error_t n20_crypto_boringssl_sign(struct n20_crypto_context_s*
             uint8_t signature_buffer[104];
             *signature_size_in_out = sizeof(signature_buffer);
             if (1 != EVP_DigestSignFinal(md_ctx.get(), signature_buffer, signature_size_in_out)) {
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
 
             // EVP_DigestSignFinal returned the signature as ASN.1 sequence
@@ -702,48 +703,48 @@ static n20_crypto_error_t n20_crypto_boringssl_sign(struct n20_crypto_context_s*
                    s_size);
             *signature_size_in_out = signature_size;
 
-            return n20_crypto_error_ok_e;
+            return n20_error_ok_e;
         }
         case n20_crypto_key_type_cdi_e:
         default:
-            return n20_crypto_error_invalid_key_e;
+            return n20_error_crypto_invalid_key_e;
     }
 }
 
-static n20_crypto_error_t n20_crypto_boringssl_get_cdi(struct n20_crypto_context_s* ctx,
-                                                       n20_crypto_key_t* key_out) {
+static n20_error_t n20_crypto_boringssl_get_cdi(struct n20_crypto_context_s* ctx,
+                                                n20_crypto_key_t* key_out) {
     if (ctx == nullptr) {
-        return n20_crypto_error_invalid_context_e;
+        return n20_error_crypto_invalid_context_e;
     }
 
     if (key_out == nullptr) {
-        return n20_crypto_error_unexpected_null_key_out_e;
+        return n20_error_crypto_unexpected_null_key_out_e;
     }
 
     auto bssl_ctx = context_cast(ctx);
     *key_out = reinterpret_cast<n20_crypto_key_t*>(static_cast<n20_bssl_key_base*>(&bssl_ctx->cdi));
 
-    return n20_crypto_error_ok_e;
+    return n20_error_ok_e;
 }
 
 struct BoringsslDeleter {
     void operator()(void* p) { OPENSSL_free(p); }
 };
 
-static n20_crypto_error_t n20_crypto_boringssl_key_get_public_key(struct n20_crypto_context_s* ctx,
-                                                                  n20_crypto_key_t key_in,
-                                                                  uint8_t* public_key_out,
-                                                                  size_t* public_key_size_in_out) {
+static n20_error_t n20_crypto_boringssl_key_get_public_key(struct n20_crypto_context_s* ctx,
+                                                           n20_crypto_key_t key_in,
+                                                           uint8_t* public_key_out,
+                                                           size_t* public_key_size_in_out) {
     if (ctx == nullptr) {
-        return n20_crypto_error_invalid_context_e;
+        return n20_error_crypto_invalid_context_e;
     }
 
     if (key_in == nullptr) {
-        return n20_crypto_error_unexpected_null_key_in_e;
+        return n20_error_crypto_unexpected_null_key_in_e;
     }
 
     if (public_key_size_in_out == nullptr) {
-        return n20_crypto_error_unexpected_null_size_e;
+        return n20_error_crypto_unexpected_null_size_e;
     }
 
     auto bssl_base_key = reinterpret_cast<n20_bssl_key_base*>(key_in);
@@ -760,12 +761,12 @@ static n20_crypto_error_t n20_crypto_boringssl_key_get_public_key(struct n20_cry
             break;
         case n20_crypto_key_type_cdi_e:
         default:
-            return n20_crypto_error_invalid_key_e;
+            return n20_error_crypto_invalid_key_e;
     }
 
     if (*public_key_size_in_out < public_key_size || public_key_out == nullptr) {
         *public_key_size_in_out = public_key_size;
-        return n20_crypto_error_insufficient_buffer_size_e;
+        return n20_error_crypto_insufficient_buffer_size_e;
     }
 
     auto bssl_evp_key = static_cast<n20_bssl_evp_pkey*>(bssl_base_key);
@@ -778,13 +779,13 @@ static n20_crypto_error_t n20_crypto_boringssl_key_get_public_key(struct n20_cry
                 bssl_evp_key->type != n20_crypto_key_type_secp384r1_e) {
                 // If this happened this implementation handed out
                 // inconsistent data or the user did something undefined.
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
 
             uint8_t* x962_key_info = NULL;
             int rc_der_len = i2d_PublicKey(key.get(), &x962_key_info);
             if (rc_der_len <= 0) {
-                return n20_crypto_error_no_resources_e;
+                return n20_error_crypto_no_resources_e;
             }
             auto x962_key_info_guard = std::unique_ptr<uint8_t, BoringsslDeleter>(x962_key_info);
 
@@ -793,42 +794,42 @@ static n20_crypto_error_t n20_crypto_boringssl_key_get_public_key(struct n20_cry
             // The key size should be exactly twice the key size + one byte for
             // the compression header, which must be 0x04 indication no compression.
             if ((size_t)rc_der_len != *public_key_size_in_out + 1 || x962_key_info[0] != 0x04) {
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
 
             // Cut off the compression header, because the nat20 crypto interface requires
             // that the public key is always an uncompressed point.
             memcpy(public_key_out, x962_key_info_guard.get() + 1, *public_key_size_in_out);
 
-            return n20_crypto_error_ok_e;
+            return n20_error_ok_e;
         }
         case EVP_PKEY_ED25519: {
             if (bssl_base_key->type != n20_crypto_key_type_ed25519_e) {
                 // If this happened this implementation handed out
                 // inconsistent data or the user did something undefined.
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
 
             auto rc =
                 EVP_PKEY_get_raw_public_key(key.get(), public_key_out, public_key_size_in_out);
             if (!rc || *public_key_size_in_out != 32) {
-                return n20_crypto_error_implementation_specific_e;
+                return n20_error_crypto_implementation_specific_e;
             }
-            return n20_crypto_error_ok_e;
+            return n20_error_ok_e;
         }
         default:
-            return n20_crypto_error_invalid_key_e;
+            return n20_error_crypto_invalid_key_e;
     }
 }
 
-static n20_crypto_error_t n20_crypto_boringssl_key_free(struct n20_crypto_context_s* ctx,
-                                                        n20_crypto_key_t key_in) {
+static n20_error_t n20_crypto_boringssl_key_free(struct n20_crypto_context_s* ctx,
+                                                 n20_crypto_key_t key_in) {
     if (ctx == nullptr) {
-        return n20_crypto_error_invalid_context_e;
+        return n20_error_crypto_invalid_context_e;
     }
 
     if (key_in == NULL) {
-        return n20_crypto_error_ok_e;
+        return n20_error_ok_e;
     }
 
     auto bssl_key = reinterpret_cast<n20_bssl_key_base*>(key_in);
@@ -838,12 +839,12 @@ static n20_crypto_error_t n20_crypto_boringssl_key_free(struct n20_crypto_contex
     // there is nothing to do here in this case.
     auto bssl_ctx = context_cast(ctx);
     if (bssl_key == static_cast<n20_bssl_key_base*>(&bssl_ctx->cdi)) {
-        return n20_crypto_error_ok_e;
+        return n20_error_ok_e;
     }
 
     delete bssl_key;
 
-    return n20_crypto_error_ok_e;
+    return n20_error_ok_e;
 }
 
 static n20_crypto_context_t bssl_ctx{n20_crypto_boringssl_digest,
@@ -853,15 +854,15 @@ static n20_crypto_context_t bssl_ctx{n20_crypto_boringssl_digest,
                                      n20_crypto_boringssl_key_get_public_key,
                                      n20_crypto_boringssl_key_free};
 
-extern "C" n20_crypto_error_t n20_crypto_open_boringssl(n20_crypto_context_t** ctx,
-                                                        n20_slice_t const* cdi) {
+extern "C" n20_error_t n20_crypto_open_boringssl(n20_crypto_context_t** ctx,
+                                                 n20_slice_t const* cdi) {
     if (ctx == NULL || cdi == NULL || cdi->buffer == NULL || cdi->size == 0) {
-        return n20_crypto_error_unexpected_null_e;
+        return n20_error_crypto_unexpected_null_e;
     }
 
     auto new_ctx = std::make_unique<n20_bssl_context>();
     if (!new_ctx) {
-        return n20_crypto_error_no_resources_e;
+        return n20_error_crypto_no_resources_e;
     }
 
     new_ctx->cdi.type = n20_crypto_key_type_cdi_e;
@@ -870,14 +871,14 @@ extern "C" n20_crypto_error_t n20_crypto_open_boringssl(n20_crypto_context_t** c
     *ctx = static_cast<n20_crypto_context_t*>(new_ctx.release());
     **ctx = bssl_ctx;
 
-    return n20_crypto_error_ok_e;
+    return n20_error_ok_e;
 }
 
-extern "C" n20_crypto_error_t n20_crypto_close_boringssl(n20_crypto_context_t* ctx) {
+extern "C" n20_error_t n20_crypto_close_boringssl(n20_crypto_context_t* ctx) {
     if (ctx == NULL) {
-        return n20_crypto_error_unexpected_null_e;
+        return n20_error_crypto_unexpected_null_e;
     }
 
     auto tbd_context = std::unique_ptr<n20_bssl_context>(context_cast(ctx));
-    return n20_crypto_error_ok_e;
+    return n20_error_ok_e;
 }

--- a/src/crypto/crypto_boringssl.cpp
+++ b/src/crypto/crypto_boringssl.cpp
@@ -123,7 +123,7 @@ static n20_error_t n20_crypto_boringssl_digest(struct n20_crypto_context_s* ctx,
 
     EVP_MD const* md = digest_enum_to_bssl_evp_md(alg_in);
     if (md == nullptr) {
-        return n20_error_crypto_unkown_algorithm_e;
+        return n20_error_crypto_unknown_algorithm_e;
     }
     size_t digest_size = digest_enum_to_size(alg_in);
 
@@ -221,7 +221,7 @@ static std::variant<n20_error_t, BIGNUM_PTR_t> rfc6979_k_generation(
 
     auto md = digest_enum_to_bssl_evp_md(digest_algorithm);
     if (md == nullptr) {
-        return n20_error_crypto_unkown_algorithm_e;
+        return n20_error_crypto_unknown_algorithm_e;
     }
 
     auto digest_size = digest_enum_to_size(digest_algorithm);

--- a/src/crypto/test/crypto_boringssl.cpp
+++ b/src/crypto/test/crypto_boringssl.cpp
@@ -33,11 +33,11 @@ uint8_t const test_cdi[] = {
     0xbb, 0xe0, 0x21, 0xf5, 0x87, 0x1c, 0x6c, 0x0c, 0x30, 0x2b, 0x32, 0x4f, 0x4c, 0x44, 0xd1, 0x26,
     0xca, 0x35, 0x6b, 0xc3, 0xc5, 0x0e, 0x17, 0xc6, 0x21, 0xad, 0x1d, 0x32, 0xbd, 0x6e, 0x35, 0x08};
 
-n20_crypto_error_t CryptoImplBSSL::open(n20_crypto_context_t** ctx) {
+n20_error_t CryptoImplBSSL::open(n20_crypto_context_t** ctx) {
     n20_slice_t cdi = {sizeof(test_cdi), const_cast<uint8_t*>(&test_cdi[0])};
     return n20_crypto_open_boringssl(ctx, &cdi);
 }
-n20_crypto_error_t CryptoImplBSSL::close(n20_crypto_context_t* ctx) {
+n20_error_t CryptoImplBSSL::close(n20_crypto_context_t* ctx) {
     return n20_crypto_close_boringssl(ctx);
 }
 
@@ -54,7 +54,7 @@ n20_crypto_error_t CryptoImplBSSL::close(n20_crypto_context_t* ctx) {
  * it is not part of the public API and should not be used outside of
  * the test suite.
  */
-extern std::variant<n20_crypto_error_t, bssl::UniquePtr<BIGNUM>> __n20_testing_rfc6979_k_generation(
+extern std::variant<n20_error_t, bssl::UniquePtr<BIGNUM>> __n20_testing_rfc6979_k_generation(
     std::vector<uint8_t> const& x_octets,
     std::optional<std::vector<uint8_t>> const& m_octets,
     n20_crypto_digest_algorithm_t digest_algorithm,

--- a/src/crypto/test/crypto_boringssl.h
+++ b/src/crypto/test/crypto_boringssl.h
@@ -19,6 +19,6 @@
 #include <nat20/crypto.h>
 
 struct CryptoImplBSSL {
-    static n20_crypto_error_t open(n20_crypto_context_t** ctx);
-    static n20_crypto_error_t close(n20_crypto_context_t* ctx);
+    static n20_error_t open(n20_crypto_context_t** ctx);
+    static n20_error_t close(n20_crypto_context_t* ctx);
 };

--- a/src/crypto/test/crypto_implementations_to_test.h
+++ b/src/crypto/test/crypto_implementations_to_test.h
@@ -22,8 +22,8 @@
 // create a class that implements the following static
 // member functions.
 // struct MyCryptoImplementation {
-//     static n20_crypto_error_t open(n20_crypto_context_t** ctx);
-//     static n20_crypto_error_t close(n20_crypto_context_t* ctx);
+//     static n20_error_t open(n20_crypto_context_t** ctx);
+//     static n20_error_t close(n20_crypto_context_t* ctx);
 // };
 // Include it here and then add the class name to the types list below.
 


### PR DESCRIPTION
Create a an error.h file to move all error codes into.
All errors generated by the libnat20 library should be from a single ring of error codes.
This PR moves the crypto interface errors into a common error codes header files and moves the crypto error codes into the range 0x1000..0x1fff.