### PR TITLE
Revisit TCG DICE TCB Freshness extention rendering.

### DIFF
--- a/include/nat20/x509_ext_tcg_dice_tcb_freshness.h
+++ b/include/nat20/x509_ext_tcg_dice_tcb_freshness.h
@@ -28,30 +28,6 @@ extern "C" {
 #endif
 
 /**
- * @brief TCG DICE TCB Freshness X509 extension context.
- *
- * This is the context expected by
- * @ref n20_x509_ext_tcg_dice_tcb_freshness_content.
- * An instance of this object must be passed to the callback.
- * This is typically done using @ref n20_x509_extension by
- * initializing @ref n20_x509_extension_t.content_cb with
- * @ref n20_x509_ext_tcg_dice_tcb_freshness_content and setting
- * @ref n20_x509_extension_t.context to an instance of this
- * struct.
- *
- * (See TCG DICE Attestation Architecture Version 1.1, Section 6.3.)
- * @sa OID_TCG_DICE_TCB_FRESHNESS
- */
-struct n20_x509_ext_tcg_dice_tcb_freshness_s {
-    /**
-     * @brief  Nonce used as the freshness indicator.
-     *
-     * If nonce.buffer is NULL, the nonce is not rendered in the extension.
-     */
-    n20_slice_t nonce;
-};
-
-/**
  * @brief Alias for @ref n20_x509_ext_tcg_dice_tcb_freshness_s
  */
 typedef struct n20_x509_ext_tcg_dice_tcb_freshness_s n20_x509_ext_tcg_dice_tcb_freshness_t;
@@ -60,11 +36,13 @@ typedef struct n20_x509_ext_tcg_dice_tcb_freshness_s n20_x509_ext_tcg_dice_tcb_f
  * @brief Renders the value of a TCG DICE TCB Freshness X509 extension.
  *
  * The function expects a pointer to an instance of
- * @ref n20_x509_ext_tcg_dice_tcb_freshness_t as @p context argument.
+ * @ref n20_slice_t as @p context argument.
  *
- * If @p context is NULL, nothing is rendered, which would leave the resulting TCG DICE TCB
- * Freshness extension malformed.
+ * If @p context is NULL, or if @p context->buffer is NULL, nothing is rendered,
+ * which would leave the resulting TCG DICE TCB Freshness extension malformed.
  *
+ * (See TCG DICE Attestation Architecture Version 1.1, Section 6.3.)
+ * @sa OID_TCG_DICE_TCB_FRESHNESS
  * This function is typically not used directly but instead
  * passed to @ref n20_x509_extension by initializing an
  * instance of @ref n20_x509_extensions_t

--- a/src/core/test/x509_ext_tcg_dice_tcb_freshness.cpp
+++ b/src/core/test/x509_ext_tcg_dice_tcb_freshness.cpp
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-#include "nat20/x509_ext_tcg_dice_tcb_freshness.h"
-
 #include <gtest/gtest.h>
+#include <nat20/oid.h>
+#include <nat20/types.h>
+#include <nat20/x509.h>
+#include <nat20/x509_ext_tcg_dice_tcb_freshness.h>
 
 #include <cstdint>
 #include <cstring>
 #include <optional>
 #include <tuple>
 #include <vector>
-
-#include "nat20/oid.h"
-#include "nat20/x509.h"
 
 class X509ExtTcgTcbFreshnessTest
     : public testing::TestWithParam<
@@ -69,15 +68,11 @@ INSTANTIATE_TEST_CASE_P(TcgTcbFreshnessEncoding,
 
 TEST_P(X509ExtTcgTcbFreshnessTest, TcgTcbFreshnessEncoding) {
     auto [optional_nonce, expected] = GetParam();
-    n20_x509_ext_tcg_dice_tcb_freshness_t freshness;
-    std::memset(&freshness, 0, sizeof(freshness));
+    n20_slice_t freshness = N20_SLICE_NULL;
 
     if (optional_nonce.has_value()) {
-        freshness.nonce.buffer = optional_nonce.value().data();
-        freshness.nonce.size = optional_nonce.value().size();
-    } else {
-        freshness.nonce.buffer = nullptr;
-        freshness.nonce.size = 0;
+        freshness.buffer = optional_nonce.value().data();
+        freshness.size = optional_nonce.value().size();
     }
 
     n20_x509_extension_t extensions[] = {

--- a/src/core/x509_ext_tcg_dice_tcb_freshness.c
+++ b/src/core/x509_ext_tcg_dice_tcb_freshness.c
@@ -21,12 +21,11 @@
 
 static void n20_x509_ext_tcg_dice_tcb_freshness_sequence_content(n20_stream_t *const s,
                                                                  void *context) {
-    n20_x509_ext_tcg_dice_tcb_freshness_t const *const tcg_dice_tcb_freshness =
-        (n20_x509_ext_tcg_dice_tcb_freshness_t const *)context;
+    n20_slice_t const *const nonce = (n20_slice_t const *)context;
 
     // tcg_dice_tcb_freshness is never NULL since it's checked by
     // n20_x509_ext_tcg_dice_tcb_freshness_content.
-    n20_asn1_octetstring(s, &tcg_dice_tcb_freshness->nonce, n20_asn1_tag_info_no_override());
+    n20_asn1_octetstring(s, nonce, n20_asn1_tag_info_no_override());
 }
 
 void n20_x509_ext_tcg_dice_tcb_freshness_content(n20_stream_t *const s, void *context) {


### PR DESCRIPTION
Instead of using a new type with a single field the extension callback
now excpects n20_slice_t as context.
