### PR TITLE
Istream implementation

### DIFF
--- a/include/nat20/stream.h
+++ b/include/nat20/stream.h
@@ -234,6 +234,135 @@ extern void n20_stream_prepend(n20_stream_t *s, uint8_t const *src, size_t src_l
  */
 extern void n20_stream_put(n20_stream_t *s, uint8_t c);
 
+/**
+ * @brief Represents an input stream buffer.
+ *
+ * A `n20_istream` is used to safely extract data from a
+ * buffer of a given size.
+ */
+typedef struct n20_istream_s {
+    /**
+     * @brief Points to the beginning of the underlying buffer.
+     *
+     * This may be NULL.
+     */
+    uint8_t const *begin;
+    /**
+     * @brief The size of the underlying buffer.
+     *
+     * This is effectively ignored if @ref begin is NULL.
+     */
+    size_t size;
+    /**
+     * @brief Indicates the read position in bytes.
+     *
+     * This is initialized with `0` and incremented with
+     * each byte extracted.
+     */
+    size_t read_position;
+    /**
+     * @brief Indicates that the data requested from the stream exceeded the buffer size.
+     *
+     */
+    bool buffer_underrun;
+} n20_istream_t;
+
+/**
+ * @brief Initialize an @ref n20_istream_t structure.
+ *
+ * Initializes a structure of @ref n20_istream_t.
+ * It is safe to call this function with `buffer == NULL`.
+ * In this case the `buffer_size` parameter is effectively ignored
+ * and the stream will merely count the bytes written
+ * to it, which can be used for calculating a buffer size hint.
+ * If `buffer` is given it must point to a buffer of at least
+ * `buffer_size` bytes, or an out of bounds write will occur.
+ *
+ * ## Ownership and life time
+ *
+ * The initialized stream does not take ownership of the provided
+ * buffer and the buffer must outlive the stream object.
+ *
+ * Calling this function with `s == NULL` is safe but a noop.
+ *
+ * @param s A pointer to the to be initialized @ref n20_istream_t structure.
+ * @param buffer A pointer to the target stream buffer or NULL.
+ * @param buffer_size Size of `buffer` in bytes.
+ */
+extern void n20_istream_init(n20_istream_t *s, uint8_t const *buffer, size_t buffer_size);
+
+/**
+ * @brief Reads data from the input stream into a buffer.
+ *
+ * This function reads a specified number of bytes from the input stream
+ * into the provided buffer. If the read operation exceeds the available
+ * data in the stream, the `buffer_underrun` flag is set and the provided
+ * buffer remains unmodified. In this case, the function returns `false`.
+ *
+ * @note The function does not check for buffer overflows in the provided
+ * buffer. It is the caller's responsibility to ensure that the buffer is
+ * dereferenceable and that it is at least `buffer_size` bytes long.
+ *
+ * @param s The input stream to read from.
+ * @param buffer The buffer to store the read data.
+ * @param buffer_size The number of bytes to read.
+ * @return `true` if the read operation was successful, `false` otherwise.
+ */
+extern bool n20_istream_read(n20_istream_t *s, uint8_t *buffer, size_t buffer_size);
+
+/**
+ * @brief Reads a single byte from the input stream.
+ *
+ * This function reads a single byte from the input stream and stores it
+ * in the provided variable. If the read operation exceeds the available
+ * data in the stream, the `buffer_underrun` flag is set and the provided
+ * buffer remains unmodified. In this case, the function returns `false`.
+ *
+ * @note The function does not check for buffer overflows in the provided
+ * uint_t variable. It is the caller's responsibility to ensure that the
+ * variable is dereferenceable.
+ *
+ * @param s The input stream to read from.
+ * @param c Pointer to a variable where the read byte will be stored.
+ * @return `true` if the read operation was successful, `false` otherwise.
+ */
+extern bool n20_istream_get(n20_istream_t *s, uint8_t *c);
+
+/** @brief Gets a buffer slice from the input stream.
+ *
+ * This function advances the read position of the input stream by the
+ * specified size and returns a slice of the input stream buffer.
+ *
+ * @param s The input stream to read from.
+ * @param size The size of the slice to read.
+ * @return A pointer to the slice of the input stream buffer or NULL if
+ * the read operation exceeds the available data in the stream.
+ */
+extern uint8_t const *n20_istream_get_slice(n20_istream_t *s, size_t size);
+
+/**
+ * @brief Checks if the input stream has encountered a buffer underrun.
+ *
+ * This function returns whether the input stream has encountered a buffer
+ * underrun, which occurs when a read operation exceeds the available data
+ * in the stream.
+ *
+ * @param s The input stream to check.
+ * @return `true` if a buffer underrun has occurred, `false` otherwise.
+ */
+extern bool n20_istream_has_buffer_underrun(n20_istream_t const *s);
+
+/**
+ * @brief Gets the current read position of the input stream.
+ *
+ * This function returns the current read position in the input stream.
+ * If the stream is `NULL`, it returns 0.
+ *
+ * @param s The input stream to query.
+ * @return The current read position, or 0 if the stream is `NULL`.
+ */
+extern size_t n20_istream_read_position(n20_istream_t const *s);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/nat20/stream.h
+++ b/include/nat20/stream.h
@@ -271,12 +271,11 @@ typedef struct n20_istream_s {
  * @brief Initialize an @ref n20_istream_t structure.
  *
  * Initializes a structure of @ref n20_istream_t.
- * It is safe to call this function with `buffer == NULL`.
- * In this case the `buffer_size` parameter is effectively ignored
- * and the stream will merely count the bytes written
- * to it, which can be used for calculating a buffer size hint.
- * If `buffer` is given it must point to a buffer of at least
- * `buffer_size` bytes, or an out of bounds write will occur.
+ * It is safe to call this function with `buffer == NULL` or
+ * `buffer_size == 0`. In this case the buffer_underrun field is
+ * set to true and all subsequent calls to `n20_istream_read`,
+ * or `n20_istream_get` will return false and `n20_istream_get_slice`
+ * will return NULL.
  *
  * ## Ownership and life time
  *
@@ -302,6 +301,10 @@ extern void n20_istream_init(n20_istream_t *s, uint8_t const *buffer, size_t buf
  * @note The function does not check for buffer overflows in the provided
  * buffer. It is the caller's responsibility to ensure that the buffer is
  * dereferenceable and that it is at least `buffer_size` bytes long.
+ * If @p buffer is NULL the behavior is undefined.
+ *
+ * If @p s was not initialized with @ref n20_istream_init the behavior
+ * is undefined.
  *
  * @param s The input stream to read from.
  * @param buffer The buffer to store the read data.
@@ -319,8 +322,11 @@ extern bool n20_istream_read(n20_istream_t *s, uint8_t *buffer, size_t buffer_si
  * buffer remains unmodified. In this case, the function returns `false`.
  *
  * @note The function does not check for buffer overflows in the provided
- * uint_t variable. It is the caller's responsibility to ensure that the
+ * @p c parameter. It is the caller's responsibility to ensure that the
  * variable is dereferenceable.
+ *
+ * If @p s was not initialized with @ref n20_istream_init the behavior
+ * is undefined.
  *
  * @param s The input stream to read from.
  * @param c Pointer to a variable where the read byte will be stored.
@@ -332,6 +338,12 @@ extern bool n20_istream_get(n20_istream_t *s, uint8_t *c);
  *
  * This function advances the read position of the input stream by the
  * specified size and returns a slice of the input stream buffer.
+ *
+ * If @p size exceeds the data available in the stream, the function
+ * returns NULL.
+ *
+ * If @p s was not initialized with @ref n20_istream_init the behavior
+ * is undefined.
  *
  * @param s The input stream to read from.
  * @param size The size of the slice to read.
@@ -347,6 +359,9 @@ extern uint8_t const *n20_istream_get_slice(n20_istream_t *s, size_t size);
  * underrun, which occurs when a read operation exceeds the available data
  * in the stream.
  *
+ * If @p s was not initialized with @ref n20_istream_init the behavior
+ * is undefined.
+ *
  * @param s The input stream to check.
  * @return `true` if a buffer underrun has occurred, `false` otherwise.
  */
@@ -357,6 +372,9 @@ extern bool n20_istream_has_buffer_underrun(n20_istream_t const *s);
  *
  * This function returns the current read position in the input stream.
  * If the stream is `NULL`, it returns 0.
+ *
+ * If @p s was not initialized with @ref n20_istream_init the behavior
+ * is undefined.
  *
  * @param s The input stream to query.
  * @return The current read position, or 0 if the stream is `NULL`.

--- a/include/nat20/stream.h
+++ b/include/nat20/stream.h
@@ -271,11 +271,15 @@ typedef struct n20_istream_s {
  * @brief Initialize an @ref n20_istream_t structure.
  *
  * Initializes a structure of @ref n20_istream_t.
- * It is safe to call this function with `buffer == NULL` or
- * `buffer_size == 0`. In this case the buffer_underrun field is
- * set to true and all subsequent calls to `n20_istream_read`,
- * or `n20_istream_get` will return false and `n20_istream_get_slice`
- * will return NULL.
+ * It is safe to call this function with @p buffer == NULL or
+ * @p buffer_size == 0.
+ * If @p buffer_size is 0, the stream is considered empty
+ * but in a good state. Zero size reads will succeed but
+ * any read of size greater than zero will fail and set
+ * the `buffer_underrun` flag.
+ * If @p buffer is NULL, and @p buffer_size is not 0,
+ * the stream is considered empty and in a bad state.
+ * Any read will fail and `buffer_underrun` is set.
  *
  * ## Ownership and life time
  *

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -88,7 +88,7 @@ void n20_istream_init(n20_istream_t *s, uint8_t const *buffer, size_t buffer_siz
     s->begin = buffer;
     s->size = buffer_size;
     s->read_position = 0;
-    s->buffer_underrun = buffer == NULL || buffer_size == 0;
+    s->buffer_underrun = buffer == NULL && buffer_size != 0;
 }
 
 bool n20_istream_read(n20_istream_t *s, uint8_t *buffer, size_t buffer_size) {

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -88,7 +88,7 @@ void n20_istream_init(n20_istream_t *s, uint8_t const *buffer, size_t buffer_siz
     s->begin = buffer;
     s->size = buffer_size;
     s->read_position = 0;
-    s->buffer_underrun = false;
+    s->buffer_underrun = buffer == NULL || buffer_size == 0;
 }
 
 bool n20_istream_read(n20_istream_t *s, uint8_t *buffer, size_t buffer_size) {

--- a/src/core/test/stream.cpp
+++ b/src/core/test/stream.cpp
@@ -144,7 +144,14 @@ TEST_F(IStreamTest, InitWithNullBuffer) {
     EXPECT_EQ(stream.begin, nullptr);
     EXPECT_EQ(stream.size, 100);
     EXPECT_EQ(stream.read_position, 0);
-    EXPECT_FALSE(stream.buffer_underrun);
+    EXPECT_TRUE(stream.buffer_underrun);
+
+    uint8_t read_buffer[4];
+    EXPECT_FALSE(n20_istream_read(&stream, read_buffer, sizeof(read_buffer)));
+    EXPECT_FALSE(n20_istream_get(&stream, &read_buffer[0]));
+    EXPECT_EQ(n20_istream_get_slice(&stream, 4), nullptr);
+    EXPECT_EQ(n20_istream_read_position(&stream), 0);
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
 }
 
 TEST_F(IStreamTest, InitWithNullStream) {

--- a/src/core/test/stream.cpp
+++ b/src/core/test/stream.cpp
@@ -113,8 +113,6 @@ TEST(StreamTest, StreamCounterOverflow) {
     ASSERT_TRUE(n20_stream_has_write_position_overflow(&s));
 }
 
-// Add these tests to the existing stream.cpp file
-
 class IStreamTest : public testing::Test {
    protected:
     void SetUp() override {
@@ -400,6 +398,52 @@ TEST_F(IStreamTest, EmptyBuffer) {
 
     uint8_t const* slice = n20_istream_get_slice(&stream, 1);
     EXPECT_EQ(slice, nullptr);
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+}
+
+TEST_F(IStreamTest, NullBuffer) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, nullptr, 0);  // Null buffer
+
+    uint8_t byte;
+    EXPECT_FALSE(n20_istream_get(&stream, &byte));
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+    EXPECT_EQ(n20_istream_read_position(&stream), 0);
+
+    uint8_t const* slice = n20_istream_get_slice(&stream, 1);
+    EXPECT_EQ(slice, nullptr);
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+}
+
+
+TEST_F(IStreamTest, ZeroSizeRead) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    std::vector<uint8_t> buffer(4, 0xFF);                      // Initialize with non-zero values
+    EXPECT_TRUE(n20_istream_read(&stream, buffer.data(), 0));  // Zero-size read
+    EXPECT_EQ(buffer, std::vector<uint8_t>({0xFF, 0xFF, 0xFF, 0xFF}));  // Buffer unchanged
+    EXPECT_EQ(n20_istream_read_position(&stream), 0);
+    EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+}
+
+TEST_F(IStreamTest, ZeroSizeReadNullInit) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, nullptr, 0);
+    EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+
+    EXPECT_TRUE(n20_istream_read(&stream, nullptr, 0));  // Zero-size read
+    EXPECT_EQ(n20_istream_read_position(&stream), 0);
+    EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+}
+
+TEST_F(IStreamTest, ZeroSizeReadNullInitNonZeroBufferSize) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, nullptr, 1);
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+
+    EXPECT_FALSE(n20_istream_read(&stream, nullptr, 0));  // Zero-size read
+    EXPECT_EQ(n20_istream_read_position(&stream), 0);
     EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
 }
 

--- a/src/core/test/stream.cpp
+++ b/src/core/test/stream.cpp
@@ -69,8 +69,8 @@ TEST_P(StreamTest, StreamPrepend) {
     std::reverse(bytes_to_prepend_copy.begin(), bytes_to_prepend_copy.end());
     // Flatten
     std::vector<uint8_t> expected;
-    for (auto const &bytes : bytes_to_prepend_copy) {
-        for (auto const &byte : bytes) {
+    for (auto const& bytes : bytes_to_prepend_copy) {
+        for (auto const& byte : bytes) {
             expected.push_back(byte);
         }
     }
@@ -78,7 +78,7 @@ TEST_P(StreamTest, StreamPrepend) {
     n20_stream_t s;
     uint8_t buffer[buffer_size];
     n20_stream_init(&s, buffer, buffer_size);
-    for (auto const &bytes : bytes_to_prepend) {
+    for (auto const& bytes : bytes_to_prepend) {
         n20_stream_prepend(&s, bytes.data(), bytes.size());
     }
     ASSERT_EQ(has_overflow, n20_stream_has_buffer_overflow(&s));
@@ -112,3 +112,336 @@ TEST(StreamTest, StreamCounterOverflow) {
     ASSERT_TRUE(n20_stream_has_buffer_overflow(&s));
     ASSERT_TRUE(n20_stream_has_write_position_overflow(&s));
 }
+
+// Add these tests to the existing stream.cpp file
+
+class IStreamTest : public testing::Test {
+   protected:
+    void SetUp() override {
+        // Initialize test data
+        test_data = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    }
+
+    std::vector<uint8_t> test_data;
+};
+
+TEST_F(IStreamTest, InitWithValidBuffer) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    EXPECT_EQ(stream.begin, test_data.data());
+    EXPECT_EQ(stream.size, test_data.size());
+    EXPECT_EQ(stream.read_position, 0);
+    EXPECT_FALSE(stream.buffer_underrun);
+    EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+    EXPECT_EQ(n20_istream_read_position(&stream), 0);
+}
+
+TEST_F(IStreamTest, InitWithNullBuffer) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, nullptr, 100);
+
+    EXPECT_EQ(stream.begin, nullptr);
+    EXPECT_EQ(stream.size, 100);
+    EXPECT_EQ(stream.read_position, 0);
+    EXPECT_FALSE(stream.buffer_underrun);
+}
+
+TEST_F(IStreamTest, InitWithNullStream) {
+    // Should not crash
+    n20_istream_init(nullptr, test_data.data(), test_data.size());
+}
+
+TEST_F(IStreamTest, ReadSingleBytes) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    for (size_t i = 0; i < test_data.size(); ++i) {
+        uint8_t byte;
+        EXPECT_TRUE(n20_istream_read(&stream, &byte, 1));
+        EXPECT_EQ(byte, test_data[i]);
+        EXPECT_EQ(n20_istream_read_position(&stream), i + 1);
+        EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+    }
+
+    // Try to read beyond buffer
+    uint8_t byte;
+    EXPECT_FALSE(n20_istream_read(&stream, &byte, 1));
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+    EXPECT_EQ(n20_istream_read_position(&stream), test_data.size());
+}
+
+TEST_F(IStreamTest, ReadMultipleBytes) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    std::vector<uint8_t> buffer(4);
+    EXPECT_TRUE(n20_istream_read(&stream, buffer.data(), 4));
+    EXPECT_EQ(buffer, std::vector<uint8_t>({0x01, 0x02, 0x03, 0x04}));
+    EXPECT_EQ(n20_istream_read_position(&stream), 4);
+
+    buffer.resize(4);
+    EXPECT_TRUE(n20_istream_read(&stream, buffer.data(), 4));
+    EXPECT_EQ(buffer, std::vector<uint8_t>({0x05, 0x06, 0x07, 0x08}));
+    EXPECT_EQ(n20_istream_read_position(&stream), 8);
+    EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+}
+
+TEST_F(IStreamTest, ReadExactlyBufferSize) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    std::vector<uint8_t> buffer(test_data.size());
+    EXPECT_TRUE(n20_istream_read(&stream, buffer.data(), test_data.size()));
+    EXPECT_EQ(buffer, test_data);
+    EXPECT_EQ(n20_istream_read_position(&stream), test_data.size());
+    EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+}
+
+TEST_F(IStreamTest, ReadBeyondBuffer) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    std::vector<uint8_t> buffer(test_data.size() + 1);
+    std::vector<uint8_t> original_buffer = buffer;
+
+    EXPECT_FALSE(n20_istream_read(&stream, buffer.data(), test_data.size() + 1));
+    EXPECT_EQ(buffer, original_buffer);  // Buffer should remain unchanged
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+    EXPECT_EQ(n20_istream_read_position(&stream), test_data.size());
+}
+
+TEST_F(IStreamTest, ReadAfterUnderrun) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    // Cause underrun
+    std::vector<uint8_t> buffer(test_data.size() + 1);
+    EXPECT_FALSE(n20_istream_read(&stream, buffer.data(), test_data.size() + 1));
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+
+    // Try to read again - should fail
+    uint8_t byte;
+    EXPECT_FALSE(n20_istream_read(&stream, &byte, 1));
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+}
+
+TEST_F(IStreamTest, ReadWithNullStream) {
+    uint8_t buffer[4];
+    EXPECT_FALSE(n20_istream_read(nullptr, buffer, 4));
+}
+
+TEST_F(IStreamTest, GetSingleByte) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    for (size_t i = 0; i < test_data.size(); ++i) {
+        uint8_t byte;
+        EXPECT_TRUE(n20_istream_get(&stream, &byte));
+        EXPECT_EQ(byte, test_data[i]);
+        EXPECT_EQ(n20_istream_read_position(&stream), i + 1);
+    }
+
+    // Try to get beyond buffer
+    uint8_t byte;
+    EXPECT_FALSE(n20_istream_get(&stream, &byte));
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+}
+
+TEST_F(IStreamTest, GetWithNullStream) {
+    uint8_t byte;
+    EXPECT_FALSE(n20_istream_get(nullptr, &byte));
+}
+
+TEST_F(IStreamTest, GetSliceValid) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    // Get first 4 bytes
+    uint8_t const* slice = n20_istream_get_slice(&stream, 4);
+    EXPECT_NE(slice, nullptr);
+    EXPECT_EQ(slice, test_data.data());
+    EXPECT_EQ(n20_istream_read_position(&stream), 4);
+    EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+
+    // Verify slice content
+    for (size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(slice[i], test_data[i]);
+    }
+
+    // Get remaining bytes
+    slice = n20_istream_get_slice(&stream, 4);
+    EXPECT_NE(slice, nullptr);
+    EXPECT_EQ(slice, test_data.data() + 4);
+    EXPECT_EQ(n20_istream_read_position(&stream), 8);
+    EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+}
+
+TEST_F(IStreamTest, GetSliceZeroSize) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    uint8_t const* slice = n20_istream_get_slice(&stream, 0);
+    EXPECT_NE(slice, nullptr);
+    EXPECT_EQ(slice, test_data.data());
+    EXPECT_EQ(n20_istream_read_position(&stream), 0);
+    EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+}
+
+TEST_F(IStreamTest, GetSliceExactSize) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    uint8_t const* slice = n20_istream_get_slice(&stream, test_data.size());
+    EXPECT_NE(slice, nullptr);
+    EXPECT_EQ(slice, test_data.data());
+    EXPECT_EQ(n20_istream_read_position(&stream), test_data.size());
+    EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+}
+
+TEST_F(IStreamTest, GetSliceBeyondBuffer) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    uint8_t const* slice = n20_istream_get_slice(&stream, test_data.size() + 1);
+    EXPECT_EQ(slice, nullptr);
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+    EXPECT_EQ(n20_istream_read_position(&stream), test_data.size());
+}
+
+TEST_F(IStreamTest, GetSliceAfterUnderrun) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    // Cause underrun
+    uint8_t const* slice = n20_istream_get_slice(&stream, test_data.size() + 1);
+    EXPECT_EQ(slice, nullptr);
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+
+    // Try to get slice again - should fail
+    slice = n20_istream_get_slice(&stream, 1);
+    EXPECT_EQ(slice, nullptr);
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+}
+
+TEST_F(IStreamTest, GetSliceWithNullStream) {
+    uint8_t const* slice = n20_istream_get_slice(nullptr, 4);
+    EXPECT_EQ(slice, nullptr);
+}
+
+TEST_F(IStreamTest, GetSliceOverflowProtection) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    // Move to near end of buffer
+    n20_istream_get_slice(&stream, test_data.size() - 1);
+    EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+
+    // Try to get slice that would cause overflow
+    uint8_t const* slice = n20_istream_get_slice(&stream, SIZE_MAX);
+    EXPECT_EQ(slice, nullptr);
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+    EXPECT_EQ(n20_istream_read_position(&stream), test_data.size());
+}
+
+TEST_F(IStreamTest, HasBufferUnderrunWithNullStream) {
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(nullptr));
+}
+
+TEST_F(IStreamTest, ReadPositionWithNullStream) {
+    EXPECT_EQ(n20_istream_read_position(nullptr), 0);
+}
+
+TEST_F(IStreamTest, MixedOperations) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    // Get single byte
+    uint8_t byte;
+    EXPECT_TRUE(n20_istream_get(&stream, &byte));
+    EXPECT_EQ(byte, 0x01);
+    EXPECT_EQ(n20_istream_read_position(&stream), 1);
+
+    // Get slice
+    uint8_t const* slice = n20_istream_get_slice(&stream, 3);
+    EXPECT_NE(slice, nullptr);
+    EXPECT_EQ(slice[0], 0x02);
+    EXPECT_EQ(slice[1], 0x03);
+    EXPECT_EQ(slice[2], 0x04);
+    EXPECT_EQ(n20_istream_read_position(&stream), 4);
+
+    // Read multiple bytes
+    std::vector<uint8_t> buffer(4);
+    EXPECT_TRUE(n20_istream_read(&stream, buffer.data(), 4));
+    EXPECT_EQ(buffer, std::vector<uint8_t>({0x05, 0x06, 0x07, 0x08}));
+    EXPECT_EQ(n20_istream_read_position(&stream), 8);
+    EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+
+    // Try to read more - should fail
+    EXPECT_FALSE(n20_istream_get(&stream, &byte));
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+}
+
+TEST_F(IStreamTest, EmptyBuffer) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), 0);  // Empty buffer
+
+    uint8_t byte;
+    EXPECT_FALSE(n20_istream_get(&stream, &byte));
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+    EXPECT_EQ(n20_istream_read_position(&stream), 0);
+
+    uint8_t const* slice = n20_istream_get_slice(&stream, 1);
+    EXPECT_EQ(slice, nullptr);
+    EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
+}
+
+// Parameterized test for various buffer sizes and read patterns
+class IStreamParameterizedTest : public testing::TestWithParam<std::tuple<size_t, size_t>> {
+   protected:
+    void SetUp() override {
+        buffer_size = std::get<0>(GetParam());
+        read_size = std::get<1>(GetParam());
+
+        test_data.resize(buffer_size);
+        for (size_t i = 0; i < buffer_size; ++i) {
+            test_data[i] = static_cast<uint8_t>(i & 0xFF);
+        }
+    }
+
+    std::vector<uint8_t> test_data;
+    size_t buffer_size;
+    size_t read_size;
+};
+
+TEST_P(IStreamParameterizedTest, ReadInChunks) {
+    n20_istream_t stream;
+    n20_istream_init(&stream, test_data.data(), test_data.size());
+
+    std::vector<uint8_t> read_data;
+    std::vector<uint8_t> chunk(read_size);
+
+    while (n20_istream_read_position(&stream) < test_data.size()) {
+        size_t remaining = test_data.size() - n20_istream_read_position(&stream);
+        size_t to_read = std::min(read_size, remaining);
+
+        bool success = n20_istream_read(&stream, chunk.data(), to_read);
+        EXPECT_TRUE(success);
+
+        read_data.insert(read_data.end(), chunk.begin(), chunk.begin() + to_read);
+    }
+
+    EXPECT_EQ(read_data, test_data);
+    EXPECT_FALSE(n20_istream_has_buffer_underrun(&stream));
+    EXPECT_EQ(n20_istream_read_position(&stream), test_data.size());
+}
+
+INSTANTIATE_TEST_SUITE_P(IStreamTests,
+                         IStreamParameterizedTest,
+                         testing::Values(std::make_tuple(1, 1),
+                                         std::make_tuple(8, 1),
+                                         std::make_tuple(8, 2),
+                                         std::make_tuple(8, 4),
+                                         std::make_tuple(16, 3),
+                                         std::make_tuple(100, 7),
+                                         std::make_tuple(1000, 64)));

--- a/src/core/test/stream.cpp
+++ b/src/core/test/stream.cpp
@@ -415,7 +415,6 @@ TEST_F(IStreamTest, NullBuffer) {
     EXPECT_TRUE(n20_istream_has_buffer_underrun(&stream));
 }
 
-
 TEST_F(IStreamTest, ZeroSizeRead) {
     n20_istream_t stream;
     n20_istream_init(&stream, test_data.data(), test_data.size());


### PR DESCRIPTION
Similar to n20_stream_t which offers safe writing to a buffer
n20_istream_t offers a safe way to read from a buffer lowering the risk
for out of bounds access.
