### PR TITLE
Add limits.h to messages.c

### DIFF
--- a/src/service/messages.c
+++ b/src/service/messages.c
@@ -37,6 +37,7 @@
 
 #include <nat20/cbor.h>
 #include <nat20/error.h>
+#include <nat20/limits.h>
 #include <nat20/service/messages.h>
 #include <nat20/stream.h>
 #include <nat20/types.h>


### PR DESCRIPTION
messages.c was failing to compile on the 5.15 linux kernel due to not have SIZE_MAX defined. This change adds `#include <nat20/limits.h>` to the file ensure SIZE_MAX is defined.