### PR TITLE
Fix class_create to use Function if Macro is not Defined

### DIFF
--- a/examples/linux/nat20device/nat20device.c
+++ b/examples/linux/nat20device/nat20device.c
@@ -396,7 +396,12 @@ static int __init nat20device_device_init(void) {
     }
 
     /* Create device class */
+#if defined(class_create)
+    nat20device_class = class_create(THIS_MODULE, NAT20DEVICE_DEVICE_NAME);
+#else
     nat20device_class = class_create(NAT20DEVICE_DEVICE_NAME);
+#endif
+
     if (IS_ERR(nat20device_class)) {
         ret = PTR_ERR(nat20device_class);
         pr_err("NAT20: Failed to create device class: %d\n", ret);


### PR DESCRIPTION
`class_create` is a macro in the 5.15 linux kernel. This update allows `nat20device_device_init` to work for both the 5.15 and 6.6 kernels.